### PR TITLE
42 update routing table when reciving rpc or response from rpc

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -18,9 +18,16 @@ services:
     networks:
       - kademlia_network
     environment:
-      - CONTAINER_NODE=bootstrap-node
       - NODE_PORT=3000
       - IS_BOOTSTRAP=true
+    ports:
+      - "127.0.0.1:80:80"
+    healthcheck:
+      test: curl --fail http://localhost:80 || exit 1
+      interval: 60s
+      retries: 5
+      start_period: 20s
+      timeout: 10s
 
   kademlia-node:
     build:
@@ -38,11 +45,16 @@ services:
         window: 10s    
     networks:
       - kademlia_network
+    external_links:
+        - bootstrap-node:bootstrap-node
     environment:
-      - CONTAINER_NODE=kademlia-node
-      - BOOSTRAP_NODE=bootstrap-node
+      - BOOSTRAP_NODE_HOSTNAME=bootstrap-node
+      - BOOSTRAP_NODE_PORT=3000
       - NODE_PORT=3000
       - IS_BOOTSTRAP=false
+    depends_on:
+      bootstrap-node:
+        condition: service_healthy
       
 networks:
   kademlia_network:

--- a/kademlia-node/src/kademlia/bucket.go
+++ b/kademlia-node/src/kademlia/bucket.go
@@ -56,3 +56,12 @@ func (bucket *bucket) GetContactAndCalcDistance(target *KademliaID) []Contact {
 func (bucket *bucket) Len() int {
 	return bucket.list.Len()
 }
+
+func (bucket *bucket) RemoveLastIfFull() bool {
+	if bucket.list.Len() < bucketSize {
+		return false
+	} else {
+		bucket.list.Remove(bucket.list.Back())
+		return true
+	}
+}

--- a/kademlia-node/src/kademlia/kademlia.go
+++ b/kademlia-node/src/kademlia/kademlia.go
@@ -3,7 +3,7 @@ package kademlia
 import "fmt"
 
 type Kademlia struct {
-	Network          *Network
+	Network          Network
 	KademliaNode     *KademliaNode
 	isBootsrap       bool
 	bootsrtapContact *Contact
@@ -16,13 +16,15 @@ const (
 func NewKademlia(ip string, port int, isBootsrap bool, bootstrapIp string, bootstratPort int) *Kademlia {
 
 	kademliaNode := NewKademliaNode(ip, port, isBootsrap)
-	network := &Network{
+	network := &NetworkImplementation{
 		ip,
 		port,
 		&MessageHandlerImplementation{
 			kademliaNode,
 		},
 	}
+	kademliaNode.setNetwork(network)
+
 	var contact Contact
 	if !isBootsrap {
 		contact = NewContact(
@@ -65,7 +67,7 @@ func (kademlia *Kademlia) Join() {
 
 	}
 
-	err := kademlia.Network.SendPingMessage(kademlia.bootsrtapContact)
+	err := kademlia.Network.SendPingMessage(&kademlia.KademliaNode.RoutingTable.me, kademlia.bootsrtapContact)
 	if err != nil {
 		return
 	}

--- a/kademlia-node/src/kademlia/kademlia.go
+++ b/kademlia-node/src/kademlia/kademlia.go
@@ -1,35 +1,79 @@
 package kademlia
 
+import "fmt"
+
 type Kademlia struct {
-	Network *Network
+	Network          *Network
+	KademliaNode     *KademliaNode
+	isBootsrap       bool
+	bootsrtapContact *Contact
 }
 
 const (
 	BootstrapKademliaID = "FFFFFFFF00000000000000000000000000000000"
 )
 
-func NewKademlia(ip string, port int) *Kademlia {
+func NewKademlia(ip string, port int, isBootsrap bool, bootstrapIp string, bootstratPort int) *Kademlia {
 
-	kademliaNode := NewKademliaNode(ip, port)
-	network := Network{
+	kademliaNode := NewKademliaNode(ip, port, isBootsrap)
+	network := &Network{
 		ip,
 		port,
 		&MessageHandlerImplementation{
 			kademliaNode,
 		},
 	}
+	var contact Contact
+	if !isBootsrap {
+		contact = NewContact(
+			NewKademliaID(BootstrapKademliaID),
+			bootstrapIp,
+			bootstratPort,
+		)
+	}
 	return &Kademlia{
-		Network: &network,
+		Network:          network,
+		KademliaNode:     kademliaNode,
+		isBootsrap:       isBootsrap,
+		bootsrtapContact: &contact,
 	}
 
 }
 
 func (kademlia *Kademlia) Start() {
+	if !kademlia.isBootsrap {
+		go func() {
+
+			kademlia.Join()
+
+		}()
+
+	}
+
 	err := kademlia.Network.Listen()
 	if err != nil {
 		panic(err)
 
 	}
+}
+
+func (kademlia *Kademlia) Join() {
+
+	if kademlia.isBootsrap {
+		fmt.Println("You are the bootstrap node!")
+		return
+
+	}
+
+	err := kademlia.Network.SendPingMessage(kademlia.bootsrtapContact)
+	if err != nil {
+		return
+	}
+
+	kademlia.KademliaNode.RoutingTable.AddContact(*kademlia.bootsrtapContact)
+
+	kademlia.LookupContact(&kademlia.KademliaNode.RoutingTable.me)
+
 }
 
 func (kademlia *Kademlia) LookupContact(target *Contact) {

--- a/kademlia-node/src/kademlia/kademlia.go
+++ b/kademlia-node/src/kademlia/kademlia.go
@@ -5,17 +5,17 @@ import "fmt"
 type Kademlia struct {
 	Network          Network
 	KademliaNode     *KademliaNode
-	isBootsrap       bool
-	bootsrtapContact *Contact
+	isBootstrap      bool
+	bootstrapContact *Contact
 }
 
 const (
 	BootstrapKademliaID = "FFFFFFFF00000000000000000000000000000000"
 )
 
-func NewKademlia(ip string, port int, isBootsrap bool, bootstrapIp string, bootstratPort int) *Kademlia {
+func NewKademlia(ip string, port int, isBootstrap bool, bootstrapIp string, bootstrapPort int) *Kademlia {
 
-	kademliaNode := NewKademliaNode(ip, port, isBootsrap)
+	kademliaNode := NewKademliaNode(ip, port, isBootstrap)
 	network := &NetworkImplementation{
 		ip,
 		port,
@@ -26,24 +26,24 @@ func NewKademlia(ip string, port int, isBootsrap bool, bootstrapIp string, boots
 	kademliaNode.setNetwork(network)
 
 	var contact Contact
-	if !isBootsrap {
+	if !isBootstrap {
 		contact = NewContact(
 			NewKademliaID(BootstrapKademliaID),
 			bootstrapIp,
-			bootstratPort,
+			bootstrapPort,
 		)
 	}
 	return &Kademlia{
 		Network:          network,
 		KademliaNode:     kademliaNode,
-		isBootsrap:       isBootsrap,
-		bootsrtapContact: &contact,
+		isBootstrap:      isBootstrap,
+		bootstrapContact: &contact,
 	}
 
 }
 
 func (kademlia *Kademlia) Start() {
-	if !kademlia.isBootsrap {
+	if !kademlia.isBootstrap {
 		go func() {
 
 			kademlia.Join()
@@ -61,18 +61,18 @@ func (kademlia *Kademlia) Start() {
 
 func (kademlia *Kademlia) Join() {
 
-	if kademlia.isBootsrap {
+	if kademlia.isBootstrap {
 		fmt.Println("You are the bootstrap node!")
 		return
 
 	}
 
-	err := kademlia.Network.SendPingMessage(&kademlia.KademliaNode.RoutingTable.me, kademlia.bootsrtapContact)
+	err := kademlia.Network.SendPingMessage(&kademlia.KademliaNode.RoutingTable.me, kademlia.bootstrapContact)
 	if err != nil {
 		return
 	}
 
-	kademlia.KademliaNode.RoutingTable.AddContact(*kademlia.bootsrtapContact)
+	kademlia.KademliaNode.RoutingTable.AddContact(*kademlia.bootstrapContact)
 
 	kademlia.LookupContact(&kademlia.KademliaNode.RoutingTable.me)
 

--- a/kademlia-node/src/kademlia/kademlia_node.go
+++ b/kademlia-node/src/kademlia/kademlia_node.go
@@ -1,10 +1,5 @@
 package kademlia
 
-import (
-	"os"
-	"strings"
-)
-
 const (
 	NumberOfClosestNodesToRetrieved = 3
 )
@@ -14,14 +9,11 @@ type KademliaNode struct {
 	DataStore    *DataStore
 }
 
-func NewKademliaNode(ip string, port int) *KademliaNode {
+func NewKademliaNode(ip string, port int, isBootstrap bool) *KademliaNode {
 	var routingTable *RoutingTable
 	var kademliaID KademliaID
 
-	IS_BOOTSTRAP_STR := os.Getenv("IS_BOOTSTRAP")
-	IS_BOOTSTRAP := strings.ToLower(IS_BOOTSTRAP_STR) == "true"
-
-	if IS_BOOTSTRAP {
+	if isBootstrap {
 		kademliaID = *NewKademliaID(BootstrapKademliaID)
 	} else {
 		kademliaID = *NewRandomKademliaID()

--- a/kademlia-node/src/kademlia/kademlia_node_test.go
+++ b/kademlia-node/src/kademlia/kademlia_node_test.go
@@ -1,0 +1,70 @@
+package kademlia
+
+import (
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestUpdateRoutingTableEmptyTable(t *testing.T) {
+	kademliaNode := NewKademliaNode("127.0.0.1", 3002, false)
+
+	kademliaNode.setNetwork(&NetworkImplementation{})
+
+	contact := NewContact(NewKademliaID("FFFFFFFF00000000000000000000000000000000"), "198.168.1.1", 5000)
+
+	fmt.Println("Updating an empty routing table with: " + contact.String())
+
+	kademliaNode.updateRoutingTable(contact)
+
+	bucket := kademliaNode.RoutingTable.buckets[kademliaNode.RoutingTable.getBucketIndex(contact.ID)]
+	front := bucket.list.Front().Value.(Contact)
+	fmt.Println("New front is: " + front.String())
+	assert.Equal(t, contact, bucket.list.Front().Value.(Contact))
+}
+
+type NetworkMock struct{}
+
+func (network *NetworkMock) Listen() error {
+	return nil
+}
+func (network *NetworkMock) Send(ip string, port int, message []byte, timeOut time.Duration) ([]byte, error) {
+	return nil, nil
+}
+func (network *NetworkMock) SendPingMessage(from *Contact, contact *Contact) error {
+	return nil
+}
+func (network *NetworkMock) SendFindContactMessage(from *Contact, contact *Contact) ([]Contact, error) {
+	return nil, nil
+}
+func (network *NetworkMock) SendFindDataMessage(from *Contact, contact *Contact, key *Key) ([]Contact, string, error) {
+	return nil, "", nil
+}
+func (network *NetworkMock) SendStoreMessage(from *Contact, contact *Contact, value string) bool {
+	return false
+}
+
+func TestUpdateRoutingTableFullTable(t *testing.T) {
+	kademliaNode := NewKademliaNode("127.0.0.1", 3002, false)
+	kademliaNode.setNetwork(&NetworkMock{})
+
+	contact := NewContact(NewKademliaID("FFFFFFFF00000000000000000000000000000000"), "198.168.1.1", 5000)
+
+	bucket := kademliaNode.RoutingTable.buckets[kademliaNode.RoutingTable.getBucketIndex(contact.ID)]
+
+	for bucket.Len() < bucketSize {
+		randomContact := NewContact(NewRandomKademliaID(), "198.168.1.1", 5000)
+
+		bucket.AddContact(randomContact)
+	}
+	fmt.Println("Updating a full routing table with: " + contact.String())
+
+	kademliaNode.updateRoutingTable(contact)
+
+	front := bucket.list.Front().Value.(Contact)
+	fmt.Println("New front is: " + front.String())
+
+	assert.Equal(t, contact, bucket.list.Front().Value.(Contact))
+}

--- a/kademlia-node/src/kademlia/kademlia_test.go
+++ b/kademlia-node/src/kademlia/kademlia_test.go
@@ -1,0 +1,20 @@
+package kademlia
+
+import (
+	"testing"
+	"time"
+)
+
+func TestJoin(t *testing.T) {
+	kademliaBootsrap := NewKademlia("127.0.0.1", 3001, true, "nil", 0)
+
+	go kademliaBootsrap.Start()
+
+	time.Sleep(time.Second)
+
+	kademlia := NewKademlia("127.0.0.1", 3002, false, "127.0.0.1", 3001)
+
+	kademlia.Join()
+
+	// assert.Fail(t, "Join failed!")
+}

--- a/kademlia-node/src/kademlia/message.go
+++ b/kademlia-node/src/kademlia/message.go
@@ -1,5 +1,7 @@
 package kademlia
 
+import "errors"
+
 type MessageType string
 
 const (
@@ -12,17 +14,27 @@ const (
 	STORE_RESPONSE MessageType = "STORE_RESPONSE"
 )
 
+func (messageType MessageType) IsValid() error {
+	switch messageType {
+	case ERROR, PING, PONG, FIND_NODE, FIND_DATA, STORE, STORE_RESPONSE: // Add new messageTypes to the case, so it is seen as a valid type
+		return nil
+	}
+	return errors.New("Invalid message type")
+}
+
 type Message struct {
 	MessageType MessageType `json:"messageType"`
+	Contact     Contact     `json:"contact"`
 }
 
 type Error struct {
 	Message
 }
 
-func NewErrorMessage() Error {
+func NewErrorMessage(contact Contact) Error {
 	message := Message{
 		MessageType: ERROR,
+		Contact:     contact,
 	}
 	return Error{
 		message,
@@ -31,31 +43,29 @@ func NewErrorMessage() Error {
 
 type Ping struct {
 	Message
-	FromAddress string `json:"fromAddress"`
 }
 
-func NewPingMessage(fromAddress string) Ping {
+func NewPingMessage(contact Contact) Ping {
 	message := Message{
 		MessageType: PING,
+		Contact:     contact,
 	}
 	return Ping{
 		message,
-		fromAddress,
 	}
 }
 
 type Pong struct {
 	Message
-	FromAddress string `json:"fromAddress"`
 }
 
-func NewAckPingMessage(fromAddress string) Pong {
+func NewPongMessage(contact Contact) Pong {
 	message := Message{
 		MessageType: PONG,
+		Contact:     contact,
 	}
 	return Pong{
 		message,
-		fromAddress,
 	}
 }
 
@@ -65,9 +75,10 @@ type FindNode struct {
 	ID          *KademliaID
 }
 
-func NewFindNodeMessage(fromAddress string, id *KademliaID) FindNode {
+func NewFindNodeMessage(contact Contact, fromAddress string, id *KademliaID) FindNode {
 	message := Message{
 		MessageType: FIND_NODE,
+		Contact:     contact,
 	}
 	return FindNode{
 		message,
@@ -83,9 +94,10 @@ type FindData struct {
 	Key         *Key
 }
 
-func NewFindDataMessage(fromAddress string, id *KademliaID, key *Key) FindData {
+func NewFindDataMessage(contact Contact, fromAddress string, id *KademliaID, key *Key) FindData {
 	message := Message{
 		MessageType: FIND_DATA,
+		Contact:     contact,
 	}
 	return FindData{
 		message,
@@ -103,9 +115,10 @@ type Store struct {
 	Value       string
 }
 
-func NewStoreMessage(fromAddress string, key *Key, id *KademliaID, value string) Store {
+func NewStoreMessage(contact Contact, fromAddress string, key *Key, id *KademliaID, value string) Store {
 	message := Message{
 		MessageType: STORE,
+		Contact:     contact,
 	}
 
 	return Store{
@@ -122,9 +135,10 @@ type StoreResponse struct {
 	StoreSuccess bool `json:"storeSuccess"`
 }
 
-func NewStoreResponseMessage() StoreResponse {
+func NewStoreResponseMessage(contact Contact) StoreResponse {
 	message := Message{
 		MessageType: STORE_RESPONSE,
+		Contact:     contact,
 	}
 
 	// change this value in message_handler

--- a/kademlia-node/src/kademlia/network.go
+++ b/kademlia-node/src/kademlia/network.go
@@ -1,7 +1,6 @@
 package kademlia
 
 import (
-	"bufio"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -32,6 +31,7 @@ func (network *Network) Listen() error {
 	fmt.Printf("server listening %s:%d\n", network.Ip, network.Port)
 
 	for {
+		fmt.Println("New listener...")
 		data := make([]byte, 1024)
 		len, remote, err := conn.ReadFromUDP(data[:])
 		if err != nil {
@@ -45,7 +45,7 @@ func (network *Network) Listen() error {
 				log.Printf("Failed to handle response message: %v\n", err)
 				return
 			}
-			myConn.WriteToUDP([]byte(string(response)+"\n"), remote)
+			myConn.WriteToUDP(response, remote)
 
 		}(conn)
 
@@ -73,9 +73,13 @@ func (network *Network) Send(ip string, port int, message []byte, timeOut time.D
 
 	responseChannel := make(chan []byte)
 	go func() {
-		// Read from the connection untill a new line is send
-		data, _ := bufio.NewReader(conn).ReadString('\n')
-		responseChannel <- []byte(data)
+		// Read from the connection
+		data := make([]byte, 1024)
+		len, _, err := conn.ReadFromUDP(data[:])
+		if err != nil {
+			return
+		}
+		responseChannel <- data[:len]
 
 	}()
 

--- a/kademlia-node/src/kademlia/network.go
+++ b/kademlia-node/src/kademlia/network.go
@@ -9,13 +9,22 @@ import (
 	"time"
 )
 
-type Network struct {
+type Network interface {
+	Listen() error
+	Send(ip string, port int, message []byte, timeOut time.Duration) ([]byte, error)
+	SendPingMessage(from *Contact, contact *Contact) error
+	SendFindContactMessage(from *Contact, contact *Contact) ([]Contact, error)
+	SendFindDataMessage(from *Contact, contact *Contact, key *Key) ([]Contact, string, error)
+	SendStoreMessage(from *Contact, contact *Contact, value string) bool
+}
+
+type NetworkImplementation struct {
 	Ip             string
 	Port           int
 	MessageHandler MessageHandler
 }
 
-func (network *Network) Listen() error {
+func (network *NetworkImplementation) Listen() error {
 	// listen to incoming udp packets
 	conn, err := net.ListenUDP("udp", &net.UDPAddr{
 		IP:   net.ParseIP(network.Ip),
@@ -31,7 +40,6 @@ func (network *Network) Listen() error {
 	fmt.Printf("server listening %s:%d\n", network.Ip, network.Port)
 
 	for {
-		fmt.Println("New listener...")
 		data := make([]byte, 1024)
 		len, remote, err := conn.ReadFromUDP(data[:])
 		if err != nil {
@@ -53,7 +61,7 @@ func (network *Network) Listen() error {
 
 }
 
-func (network *Network) Send(ip string, port int, message []byte, timeOut time.Duration) ([]byte, error) {
+func (network *NetworkImplementation) Send(ip string, port int, message []byte, timeOut time.Duration) ([]byte, error) {
 	conn, err := net.DialUDP("udp", nil, &net.UDPAddr{
 		IP:   net.ParseIP(ip),
 		Port: port,
@@ -85,7 +93,11 @@ func (network *Network) Send(ip string, port int, message []byte, timeOut time.D
 
 	select {
 	case response := <-responseChannel:
-		return response, nil
+		if _, err := network.MessageHandler.HandleMessage(response); err != nil {
+			return nil, err
+		} else {
+			return response, nil
+		}
 	case <-time.After(timeOut):
 		return nil, errors.New("time out error")
 
@@ -93,8 +105,8 @@ func (network *Network) Send(ip string, port int, message []byte, timeOut time.D
 
 }
 
-func (network *Network) SendPingMessage(contact *Contact) error {
-	ping := NewPingMessage(network.Ip)
+func (network *NetworkImplementation) SendPingMessage(from *Contact, contact *Contact) error {
+	ping := NewPingMessage(*from)
 	bytes, err := json.Marshal(ping)
 	if err != nil {
 		log.Printf("Failed to send ping message to the server: %v\n", err)
@@ -121,13 +133,13 @@ func (network *Network) SendPingMessage(contact *Contact) error {
 		return errUnmarshalAckPing
 	}
 
-	fmt.Println(pong.FromAddress + " acknowledged your ping")
+	fmt.Println(pong.Contact.Ip + " acknowledged your ping")
 	return nil
 
 }
 
-func (network *Network) SendFindContactMessage(contact *Contact) ([]Contact, error) {
-	findN := NewFindNodeMessage(network.Ip, contact.ID)
+func (network *NetworkImplementation) SendFindContactMessage(from *Contact, contact *Contact) ([]Contact, error) {
+	findN := NewFindNodeMessage(*from, network.Ip, contact.ID)
 	bytes, err := json.Marshal(findN)
 	if err != nil {
 		log.Printf("Error when marshaling `findN`: %v\n", err)
@@ -146,8 +158,8 @@ func (network *Network) SendFindContactMessage(contact *Contact) ([]Contact, err
 	return arrayOfContacts, nil
 }
 
-func (network *Network) SendFindDataMessage(contact *Contact, key *Key) ([]Contact, string, error) {
-	findData := NewFindDataMessage(network.Ip, contact.ID, key)
+func (network *NetworkImplementation) SendFindDataMessage(from *Contact, contact *Contact, key *Key) ([]Contact, string, error) {
+	findData := NewFindDataMessage(*from, network.Ip, contact.ID, key)
 	bytes, err := json.Marshal(findData)
 	if err != nil {
 		return nil, "", err
@@ -171,9 +183,9 @@ func (network *Network) SendFindDataMessage(contact *Contact, key *Key) ([]Conta
 
 }
 
-func (network *Network) SendStoreMessage(contact *Contact, value string) bool {
+func (network *NetworkImplementation) SendStoreMessage(from *Contact, contact *Contact, value string) bool {
 	key := HashToKey(value)
-	store := NewStoreMessage(network.Ip, key, contact.ID, value)
+	store := NewStoreMessage(*from, network.Ip, key, contact.ID, value)
 	bytes, err := json.Marshal(store)
 	if err != nil {
 		log.Printf("Error when marshaling `store` message: %v\n", err)

--- a/kademlia-node/src/kademlia/network_test.go
+++ b/kademlia-node/src/kademlia/network_test.go
@@ -1,7 +1,6 @@
 package kademlia
 
 import (
-	"bufio"
 	"encoding/json"
 	"fmt"
 	"net"
@@ -57,9 +56,13 @@ func mockSend(t *testing.T, ip string, port int, message []byte, timeOut time.Du
 
 	responseChannel := make(chan []byte)
 	go func() {
-		// Read from the connection untill a new line is send
-		data, _ := bufio.NewReader(conn).ReadString('\n')
-		responseChannel <- []byte(data)
+		// Read from the connection
+		data := make([]byte, 1024)
+		len, _, err := conn.ReadFromUDP(data[:])
+		if err != nil {
+			return
+		}
+		responseChannel <- data[:len]
 
 	}()
 

--- a/kademlia-node/src/main.go
+++ b/kademlia-node/src/main.go
@@ -3,16 +3,48 @@ package main
 import (
 	"fmt"
 	"net"
+	"net/http"
 	"os"
 	"strconv"
+	"strings"
 
 	"github.com/arianfiftyone/src/kademlia"
 )
 
+func health(w http.ResponseWriter, req *http.Request) {
+	fmt.Fprintf(w, "alive\n")
+}
+
 func main() {
 
+	BOOSTRAP_NODE_HOSTNAME := os.Getenv("BOOSTRAP_NODE_HOSTNAME")
+
+	IS_BOOTSTRAP_STR := os.Getenv("IS_BOOTSTRAP")
+	isBootsrap := strings.ToLower(IS_BOOTSTRAP_STR) == "true"
+
+	var bootstrapPort int
+	var bootstrapIp string
+
+	if !isBootsrap {
+		bootstrapIps, err := net.LookupIP(BOOSTRAP_NODE_HOSTNAME)
+		if err != nil {
+			panic(err)
+
+		}
+		BOOSTRAP_NODE_PORT_STR := os.Getenv("BOOSTRAP_NODE_PORT")
+		bootstrapPort, err = strconv.Atoi(BOOSTRAP_NODE_PORT_STR)
+		if err != nil {
+			panic(err)
+		}
+		bootstrapIp = bootstrapIps[0].String()
+
+	}
+
 	NODE_PORT_STR := os.Getenv("NODE_PORT")
-	NODE_PORT, _ := strconv.Atoi(NODE_PORT_STR)
+	port, err := strconv.Atoi(NODE_PORT_STR)
+	if err != nil {
+		panic(err)
+	}
 
 	hostname, err := os.Hostname()
 	if err != nil {
@@ -24,7 +56,13 @@ func main() {
 
 	}
 	ip := ips[0].String()
-	kademliaInstance := kademlia.NewKademlia(ip, NODE_PORT)
+	kademliaInstance := kademlia.NewKademlia(ip, port, isBootsrap, bootstrapIp, bootstrapPort)
+
+	if isBootsrap {
+		http.HandleFunc("/", health)
+		go http.ListenAndServe(":80", nil)
+
+	}
 
 	fmt.Printf("Starting node...\n")
 	kademliaInstance.Start()


### PR DESCRIPTION
Updates routing table when receiving a RPC or a response from an RPC. Adds contact to all RPC messages so it is known who sent the RPC. Removes the `from` variable from PING and PONG as that can be retrieved  from contact. Adds interface for network, so network can be mocked during testing.