### PR TITLE
Network joining

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -37,7 +37,7 @@ services:
     tty: true
     deploy:
       mode: replicated
-      replicas: 6
+      replicas: 2
       restart_policy:
         condition: on-failure
         delay: 5s

--- a/kademlia-node/src/kademlia/kademlia.go
+++ b/kademlia-node/src/kademlia/kademlia.go
@@ -23,6 +23,7 @@ const (
 	NumberOfAlphaContacts = 3
 )
 
+// NewKademlia gives new
 func NewKademlia(ip string, port int, isBootstrap bool, bootstrapIp string, bootstrapPort int) *Kademlia {
 
 	kademliaNode := NewKademliaNode(ip, port, isBootstrap)
@@ -85,6 +86,29 @@ func (kademlia *Kademlia) Join() {
 	kademlia.KademliaNode.RoutingTable.AddContact(*kademlia.bootstrapContact)
 
 	contacts, err := kademlia.LookupContact(kademlia.KademliaNode.RoutingTable.me.ID)
+	if err != nil {
+		return
+	}
+	for _, contact := range contacts {
+		kademlia.KademliaNode.RoutingTable.AddContact(contact)
+	}
+
+	var lowerBound *KademliaID
+	var highBound *KademliaID
+
+	if kademlia.KademliaNode.RoutingTable.me.ID.Less(kademlia.bootstrapContact.ID) {
+		lowerBound = kademlia.bootstrapContact.ID
+		highBound = NewKademliaID("FFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF")
+	} else {
+		lowerBound = NewKademliaID("0000000000000000000000000000000000000000")
+		highBound = kademlia.bootstrapContact.ID
+	}
+
+	randomKademliaIDInRnge, err := NewRandomKademliaIDInRange(lowerBound, highBound)
+	if err != nil {
+		return
+	}
+	contacts, err = kademlia.LookupContact(randomKademliaIDInRnge)
 	if err != nil {
 		return
 	}

--- a/kademlia-node/src/kademlia/kademlia_test.go
+++ b/kademlia-node/src/kademlia/kademlia_test.go
@@ -8,13 +8,13 @@ import (
 )
 
 func TestJoinWithBootstrapOnly(t *testing.T) {
-	kademliaBootsrap := NewKademlia("127.0.0.1", 3001, true, "", 0)
+	kademliaBootsrap := NewKademlia("127.0.0.1", 2000, true, "", 0)
 
 	go kademliaBootsrap.Start()
 
 	time.Sleep(time.Second)
 
-	kademlia := NewKademlia("127.0.0.1", 3002, false, "127.0.0.1", 3001)
+	kademlia := NewKademlia("127.0.0.1", 2001, false, "127.0.0.1", 2000)
 
 	kademlia.Join()
 
@@ -27,7 +27,7 @@ func TestJoinWithBootstrapOnly(t *testing.T) {
 }
 
 func TestJoinWithMultipleNodes(t *testing.T) {
-	kademliaBootsrap := NewKademlia("127.0.0.1", 3001, true, "", 0)
+	kademliaBootsrap := NewKademlia("127.0.0.1", 2001, true, "", 0)
 
 	var mockContacts = []Contact{
 		NewContact(NewRandomKademliaID(), "198.162.1.1", 3000),

--- a/kademlia-node/src/kademlia/kademlia_test.go
+++ b/kademlia-node/src/kademlia/kademlia_test.go
@@ -3,10 +3,12 @@ package kademlia
 import (
 	"testing"
 	"time"
+
+	"github.com/stretchr/testify/assert"
 )
 
-func TestJoin(t *testing.T) {
-	kademliaBootsrap := NewKademlia("127.0.0.1", 3001, true, "nil", 0)
+func TestJoinWithBootstrapOnly(t *testing.T) {
+	kademliaBootsrap := NewKademlia("127.0.0.1", 3001, true, "", 0)
 
 	go kademliaBootsrap.Start()
 
@@ -16,5 +18,35 @@ func TestJoin(t *testing.T) {
 
 	kademlia.Join()
 
-	// assert.Fail(t, "Join failed!")
+	contact := kademlia.KademliaNode.RoutingTable.me
+	assert.Equal(t, contact.ID, kademliaBootsrap.KademliaNode.RoutingTable.FindClosestContacts(contact.ID, 1)[0].ID, "The new node must be in the bootstraps routing table.")
+
+	bootstrapContact := kademliaBootsrap.KademliaNode.RoutingTable.me
+	assert.Equal(t, bootstrapContact.ID, kademlia.KademliaNode.RoutingTable.FindClosestContacts(bootstrapContact.ID, 1)[0].ID, "The bootsrapt must be in the new nodes routing table.")
+
+}
+
+func TestJoinWithMultipleNodes(t *testing.T) {
+	kademliaBootsrap := NewKademlia("127.0.0.1", 3001, true, "", 0)
+
+	var mockContacts = []Contact{
+		NewContact(NewRandomKademliaID(), "198.162.1.1", 3000),
+		NewContact(NewRandomKademliaID(), "198.162.1.2", 3000),
+		NewContact(NewRandomKademliaID(), "198.162.1.3", 3000),
+		NewContact(NewRandomKademliaID(), "198.162.1.4", 3000),
+	}
+
+	for _, contact := range mockContacts {
+		kademliaBootsrap.KademliaNode.RoutingTable.AddContact(contact)
+	}
+
+	go kademliaBootsrap.Start()
+
+	time.Sleep(time.Second)
+
+	kademlia := NewKademlia("127.0.0.1", 3002, false, "127.0.0.1", 3001)
+
+	kademlia.Join()
+
+	// TODO: add assert after lookup is completed
 }

--- a/kademlia-node/src/kademlia/kademliaid.go
+++ b/kademlia-node/src/kademlia/kademliaid.go
@@ -2,6 +2,7 @@ package kademlia
 
 import (
 	"encoding/hex"
+	"errors"
 	"math/rand"
 )
 
@@ -31,6 +32,26 @@ func NewRandomKademliaID() *KademliaID {
 		newKademliaID[i] = uint8(rand.Intn(256))
 	}
 	return &newKademliaID
+}
+
+// NewRandomKademliaIDInRange returns a new instance of a random KademliaID, within a given range
+func NewRandomKademliaIDInRange(lowBound *KademliaID, highBound *KademliaID) (*KademliaID, error) {
+	if !lowBound.Less(highBound) {
+		return nil, errors.New("the low bound is not lower than the high bound")
+	}
+
+	newKademliaID := &KademliaID{}
+	for i := 0; i < IDLength; i++ {
+		min := lowBound[i]
+		max := highBound[i]
+		diff := max - min
+		randomInt := rand.Intn(int(diff) + 1)
+		randomInt = randomInt + int(min)
+		newKademliaID[i] = byte(randomInt)
+	}
+
+	return newKademliaID, nil
+
 }
 
 // Less returns true if kademliaID < otherKademliaID (bitwise)

--- a/kademlia-node/src/kademlia/kademliaid_test.go
+++ b/kademlia-node/src/kademlia/kademliaid_test.go
@@ -1,0 +1,47 @@
+package kademlia
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestNewRandomKademliaidInRange(t *testing.T) {
+	lowerBound := NewKademliaID("000000000000000000000000000000000000001E")
+	highBound := NewKademliaID("0000000000000000000000000000000000000020")
+	kademliaId, err := NewRandomKademliaIDInRange(lowerBound, highBound)
+	fmt.Println(kademliaId)
+
+	if err != nil {
+		assert.Fail(t, err.Error())
+	}
+
+	assert.True(t, kademliaId.Less(highBound) || kademliaId.Equals(highBound))
+	assert.True(t, lowerBound.Less(kademliaId) || lowerBound.Equals(kademliaId))
+
+}
+
+func TestNewRandomKademliaidInRange2(t *testing.T) {
+	lowerBound := NewRandomKademliaID()
+	highBound := NewRandomKademliaID()
+
+	if highBound.Less(lowerBound) {
+		temp := lowerBound
+		lowerBound = highBound
+		highBound = temp
+	}
+
+	kademliaId, err := NewRandomKademliaIDInRange(lowerBound, highBound)
+	fmt.Println(lowerBound)
+
+	fmt.Println(kademliaId)
+
+	if err != nil {
+		assert.Fail(t, err.Error())
+	}
+
+	assert.True(t, kademliaId.Less(highBound) || kademliaId.Equals(highBound))
+	assert.True(t, lowerBound.Less(kademliaId) || lowerBound.Equals(kademliaId))
+
+}


### PR DESCRIPTION
A node can now join the network. First by finding the bootstrap and adding it to its routing table, then a lookup on the nodes own id and adding all the found nodes to the routing table. Lastly a lookup is performed on a id further away than the bootstrap, the found nodes are added to the routing table. 
A function to generate random kademliaId's in a given range is added to kademliaid.go, this is needed to get a kademliaId further away than the bootstrap node, during the lookup. 
Test are created for all added code and all test passes!