### PR TITLE
CLI is reworked. No more use of screen. Added test for logger.

### DIFF
--- a/kademlia-node/Dockerfile
+++ b/kademlia-node/Dockerfile
@@ -8,10 +8,11 @@ RUN apt-get install -y netcat-traditional
 
 RUN apt-get install -y screen
 
-
 WORKDIR /kademlia-node
 
 COPY /src ./src
 COPY scripts ./
 
-CMD ["sh", "./create-screen.sh"]
+RUN cd src
+
+CMD ["go", "run", "."]

--- a/kademlia-node/scripts/create-screen.sh
+++ b/kademlia-node/scripts/create-screen.sh
@@ -1,2 +1,0 @@
-#!/bin/sh
-screen -S kademlia sh -c "sh start.sh"

--- a/kademlia-node/scripts/start.sh
+++ b/kademlia-node/scripts/start.sh
@@ -1,3 +1,0 @@
-#!/bin/sh
-cd src
-go run .

--- a/kademlia-node/src/cli/command_handler.go
+++ b/kademlia-node/src/cli/command_handler.go
@@ -24,7 +24,7 @@ var (
 // `output` is the io.Writer used for data output.
 // `kademlia` represents the Kademlia node associated with this CLI
 // `commands` is a slice of program commands.
-func HandleCommands(output io.Writer, kademlia *kademlia.Kademlia, commands []string) {
+func (cli *Cli) HandleCommands(output io.Writer, kademlia *kademlia.Kademlia, commands []string) {
 
 	numArgs := len(commands)
 	command := strings.ToLower(commands[0])
@@ -69,6 +69,13 @@ func HandleCommands(output io.Writer, kademlia *kademlia.Kademlia, commands []st
 			fmt.Fprintln(output, noArgsError)
 		}
 
+	case "clear", "c":
+		if numArgs == 1 {
+			cli.Clear()
+		} else {
+			fmt.Fprintln(output, noArgsError)
+		}
+
 	default:
 		fmt.Fprintln(output, commandError)
 	}
@@ -76,7 +83,7 @@ func HandleCommands(output io.Writer, kademlia *kademlia.Kademlia, commands []st
 }
 
 func Put(kademlia kademlia.Kademlia, content string) {
-	hash, err := kademlia.Store(content) // nothing to return for now
+	hash, err := kademlia.Store(content)
 
 	if err != nil {
 		log.Printf("Error when storing content: %v\n", err)
@@ -87,7 +94,7 @@ func Put(kademlia kademlia.Kademlia, content string) {
 }
 
 func Get(kademlia kademlia.Kademlia, key *kademlia.Key) {
-	content, err := kademlia.LookupData(key) // nothing to return for now
+	content, err := kademlia.LookupData(key)
 
 	if err != nil {
 		log.Printf("Error when looking up data %v\n", err)

--- a/kademlia-node/src/cli/command_handler_test.go
+++ b/kademlia-node/src/cli/command_handler_test.go
@@ -7,13 +7,20 @@ import (
 	"testing"
 
 	"github.com/arianfiftyone/src/kademlia"
+
 	"github.com/stretchr/testify/assert"
 )
 
-func testCommand(command string) string {
+// Define a function to create a test Kademlia instance
+func createTestKademlia() *kademlia.Kademlia {
+	kademlia := kademlia.NewKademlia("localhost", 9000, true, "10.0.0.1", 100000)
+	return kademlia
+}
+
+func (cli *Cli) testCommand(command string) string {
 	output = bytes.NewBuffer(nil)
 
-	HandleCommands(output, kademlia.NewKademlia("localhost", 9000, true, "10.0.0.1", 100000), []string{command})
+	cli.HandleCommands(output, createTestKademlia(), []string{command})
 	return trimNewlineFromWriterOutput(output)
 }
 
@@ -23,51 +30,71 @@ func trimNewlineFromWriterOutput(output io.Writer) string {
 }
 
 func TestGetCommand(t *testing.T) {
-	assert.Equal(t, noArgsError, testCommand("get"))
+	kademliaInstance := createTestKademlia()
+	cli := NewCli(kademliaInstance)
+	assert.Equal(t, noArgsError, cli.testCommand("get"))
 }
 
 func TestAbbreviatedGetCommand(t *testing.T) {
-	assert.Equal(t, noArgsError, testCommand("g"))
+	kademliaInstance := createTestKademlia()
+	cli := NewCli(kademliaInstance)
+	assert.Equal(t, noArgsError, cli.testCommand("g"))
 }
 
 func TestPutCommand(t *testing.T) {
-	assert.Equal(t, noArgsError, testCommand("put"))
+	kademliaInstance := createTestKademlia()
+	cli := NewCli(kademliaInstance)
+	assert.Equal(t, noArgsError, cli.testCommand("put"))
 }
 
 func TestAbbreviatedPutCommand(t *testing.T) {
-	assert.Equal(t, noArgsError, testCommand("p"))
+	kademliaInstance := createTestKademlia()
+	cli := NewCli(kademliaInstance)
+	assert.Equal(t, noArgsError, cli.testCommand("p"))
 }
 
 func TestHelpCommand(t *testing.T) {
+	kademliaInstance := createTestKademlia()
+	cli := NewCli(kademliaInstance)
 	content := HelpPrompt()
-	assert.Equal(t, content, testCommand("help"))
+	assert.Equal(t, content, cli.testCommand("help"))
 }
 
 func TestAbbreviatedHelpCommand(t *testing.T) {
+	kademliaInstance := createTestKademlia()
+	cli := NewCli(kademliaInstance)
 	content := HelpPrompt()
-	assert.Equal(t, content, testCommand("h"))
+	assert.Equal(t, content, cli.testCommand("h"))
 }
 
 func TestKademliaIDCommand(t *testing.T) {
-	assert.Equal(t, "ffffffff00000000000000000000000000000000", testCommand("kademliaid"))
+	kademliaInstance := createTestKademlia()
+	cli := NewCli(kademliaInstance)
+	assert.Equal(t, "ffffffff00000000000000000000000000000000", cli.testCommand("kademliaid"))
 }
 
 func TestAbbreviatedKademliaIDCommand(t *testing.T) {
-	assert.Equal(t, "ffffffff00000000000000000000000000000000", testCommand("kid"))
+	kademliaInstance := createTestKademlia()
+	cli := NewCli(kademliaInstance)
+	assert.Equal(t, "ffffffff00000000000000000000000000000000", cli.testCommand("kid"))
 }
 
 func TestKillCommand(t *testing.T) {
-	assert.Equal(t, 1, exitCli("kill"))
+	kademliaInstance := createTestKademlia()
+	cli := NewCli(kademliaInstance)
+	assert.Equal(t, 1, cli.exitCli("kill"))
 }
 
 func TestAbbreviatedKillCommand(t *testing.T) {
-	assert.Equal(t, 1, exitCli("k"))
+	kademliaInstance := createTestKademlia()
+	cli := NewCli(kademliaInstance)
+	assert.Equal(t, 1, cli.exitCli("k"))
 }
 
 // `exitCLI` purpose is for testing cases(`kill`) where the function exits with `os.Exit()`
 // and is slightly modified from the source:
 // https://stackoverflow.com/questions/40615641/testing-os-exit-scenarios-in-go-with-coverage-information-c overalls-io-goverall/40801733#40801733
-func exitCli(e string) int {
+func (cli *Cli) exitCli(e string) int {
 	var got int
 	// Save current function and restore at the end:
 	oldExit := exit
@@ -82,6 +109,8 @@ func exitCli(e string) int {
 		exit = oldExit
 	}()
 
-	HandleCommands(output, nil, []string{e})
+	cli.HandleCommands(output, nil, []string{e})
 	return got
 }
+
+// TODO: Add testcase for `clear`-command

--- a/kademlia-node/src/cli/prompt.go
+++ b/kademlia-node/src/cli/prompt.go
@@ -17,6 +17,7 @@ COMMANDS:
 	kill, k      			Kills the node
 	kademliaid, kid 		Get id associated with the node	 
 	help, h      			Output this help prompt
+	clear, c				Clear the terminal
 
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 							[ MADE BY: arianfiftyone, MrDweller & asta987 ]

--- a/kademlia-node/src/go.mod
+++ b/kademlia-node/src/go.mod
@@ -5,6 +5,11 @@ go 1.21
 require github.com/stretchr/testify v1.8.4
 
 require (
+	golang.org/x/sys v0.12.0 // indirect
+	golang.org/x/term v0.12.0 // indirect
+)
+
+require (
 	github.com/davecgh/go-spew v1.1.1 // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect
 	golang.org/x/exp v0.0.0-20230905200255-921286631fa9

--- a/kademlia-node/src/go.sum
+++ b/kademlia-node/src/go.sum
@@ -6,6 +6,10 @@ github.com/stretchr/testify v1.8.4 h1:CcVxjf3Q8PM0mHUKJCdn+eZZtm5yQwehR5yeSVQQcU
 github.com/stretchr/testify v1.8.4/go.mod h1:sz/lmYIOXD/1dqDmKjjqLyZ2RngseejIcXlSw2iwfAo=
 golang.org/x/exp v0.0.0-20230905200255-921286631fa9 h1:GoHiUyI/Tp2nVkLI2mCxVkOjsbSXD66ic0XW0js0R9g=
 golang.org/x/exp v0.0.0-20230905200255-921286631fa9/go.mod h1:S2oDrQGGwySpoQPVqRShND87VCbxmc6bL1Yd2oYrm6k=
+golang.org/x/sys v0.12.0 h1:CM0HF96J0hcLAwsHPJZjfdNzs0gftsLfgKt57wWHJ0o=
+golang.org/x/sys v0.12.0/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
+golang.org/x/term v0.12.0 h1:/ZfYdc3zq+q02Rv9vGqTeSItdzZTSNDmfTi0mBAuidU=
+golang.org/x/term v0.12.0/go.mod h1:owVbMEjm3cBLCHdkQu9b1opXd4ETQWc3BhuQGKgXgvU=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405 h1:yhCVgyC4o1eVCa2tZl7eS0r+SDo693bJlVdllGtEeKM=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=

--- a/kademlia-node/src/logger/logger_test.go
+++ b/kademlia-node/src/logger/logger_test.go
@@ -1,0 +1,54 @@
+package logger
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestLog(t *testing.T) {
+	// Reset logger
+	logger = nil
+
+	Log("Test Log 1")
+	assert.Equal(t, []string{"Test Log 1"}, logger.newLogs)
+
+	Log("Test Log 2")
+	assert.Equal(t, []string{"Test Log 1", "Test Log 2"}, logger.newLogs)
+}
+
+func TestReadNewLog(t *testing.T) {
+	// Reset logger
+	logger = nil
+
+	_, err := ReadNewLog()
+	assert.Error(t, err, "No new logs available")
+
+	Log("Test Log 1")
+	log, err := ReadNewLog()
+	assert.NoError(t, err)
+	assert.Equal(t, "Test Log 1", log)
+
+	Log("Test Log 2")
+	log, err = ReadNewLog()
+	assert.NoError(t, err)
+	assert.Equal(t, "Test Log 2", log)
+
+	_, err = ReadNewLog()
+	assert.Error(t, err, "No new logs available")
+}
+
+func TestGetOldLogs(t *testing.T) {
+	// Reset logger
+	logger = nil
+
+	oldLogs := GetOldLogs()
+	assert.Empty(t, oldLogs) // `oldLogs` should be empty until `ReadNewLog()` is called.
+
+	Log("Test Log 1")
+	_, err := ReadNewLog()
+	assert.NoError(t, err)
+
+	oldLogs = GetOldLogs()
+	assert.Equal(t, []string{"Test Log 1"}, oldLogs)
+}


### PR DESCRIPTION
- The CLI does not make use of screen sessions any more. Instead we activate the CLI using `docker attach <containerID>`.
- Added a case for `clear`-command which according to issue: Implement `clear` command for CLI #48 
- Added test cases for our custom `logger`. All tests have passed.
- Ran a `go mod tidy` for repo cleanup.
- Since all scripts was for the screen session the `scripts`-folder has been removed.
- Added comments where necessary, changed some variable names as well.
- TODO: test `Put` and `Get` and update corresponding tests when the functions are implemented and functional.