### PR TITLE
65 add tests and coverage

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,6 +13,7 @@
 
 # Output of the go coverage tool, specifically when used with LiteIDE
 *.out
+coverage.html
 
 # Dependency directories (remove the comment below to include it)
 # vendor/

--- a/kademlia-node/scripts/run_coverage.sh
+++ b/kademlia-node/scripts/run_coverage.sh
@@ -1,0 +1,14 @@
+#!/bin/bash
+
+cd ../src
+
+COVERAGE_FILE="coverage.out"
+
+# Run tests with coverage for all packages in the project
+go test -coverprofile="$COVERAGE_FILE" ./...
+
+# Display coverage summary
+go tool cover -func="$COVERAGE_FILE"
+
+# Generate an HTML coverage report
+go tool cover -html="$COVERAGE_FILE" -o coverage.html

--- a/kademlia-node/src/cli/cli.go
+++ b/kademlia-node/src/cli/cli.go
@@ -28,10 +28,10 @@ const (
 )
 
 type Cli struct {
-	kademlia *kademlia.Kademlia
+	kademlia kademlia.Kademlia
 }
 
-func NewCli(kademlia *kademlia.Kademlia) *Cli {
+func NewCli(kademlia kademlia.Kademlia) *Cli {
 	return &Cli{
 		kademlia: kademlia,
 	}

--- a/kademlia-node/src/cli/cli_test.go
+++ b/kademlia-node/src/cli/cli_test.go
@@ -1,0 +1,90 @@
+package cli
+
+import (
+	"bytes"
+	"testing"
+
+	"github.com/arianfiftyone/src/kademlia"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestNewCli(t *testing.T) {
+	// Create a test Kademlia instance.
+	testKademlia := kademlia.NewKademlia("localhost", 9000, true, "10.0.0.1", 100000)
+
+	// Create a new Cli instance.
+	cli := NewCli(testKademlia)
+
+	// Verify that the created Cli instance has the correct Kademlia instance.
+	assert.Equal(t, testKademlia, cli.kademlia)
+}
+
+func TestLogMode(t *testing.T) {
+
+	// Create a capturing buffer to capture the output.
+	capturingBuffer := &bytes.Buffer{}
+	output = capturingBuffer
+
+	cli := &Cli{}
+
+	// Verify that we are in LogMode
+	mode := cli.LogMode(output)
+	assert.Equal(t, LOG, mode)
+
+	// Verify that the captured output contains the prompt message.
+	outputString := capturingBuffer.String()
+	assert.Contains(t, outputString, "You are in log mode, press `enter` to change to command mode")
+}
+
+func TestCommandMode(t *testing.T) {
+
+	// Create a capturing buffer to capture the output.
+	capturingBuffer := &bytes.Buffer{}
+	output = capturingBuffer
+
+	cli := &Cli{}
+
+	// Verify that we are in CommandMode
+	mode := cli.CommandMode(nil)
+	assert.Equal(t, COMMAND, mode)
+
+	// Verify that the captured output contains the expected prompt message.
+	outputString := capturingBuffer.String()
+	assert.Contains(t, outputString, "You are in command mode, enter `stop` to change to log mode")
+}
+
+func TestTrimWhitespace(t *testing.T) {
+	tests := []struct {
+		input    string
+		expected string
+	}{
+		{"  testing testy  ", "testing testy"}, // Leading and trailing spaces should be removed.
+		{"   ", ""},                            // Only spaces should become an empty string.
+		{"testy", "testy"},                     // No spaces, so the string should remain the same.
+	}
+
+	for _, test := range tests {
+		t.Run(test.input, func(t *testing.T) {
+			result := trimWhitespace(test.input)
+			assert.Equal(t, test.expected, result)
+		})
+	}
+}
+
+func TestSplitInput(t *testing.T) {
+	tests := []struct {
+		input    string
+		expected []string
+	}{
+		{"testing, testy ", []string{"testing,", "testy"}},                                  // Words separated by a comma and space.
+		{"  The test is  being   tested", []string{"The", "test", "is", "being", "tested"}}, // Multiple spaces as separators.
+		{"", []string{}}, // Empty input should result in an empty slice.
+	}
+
+	for _, test := range tests {
+		t.Run(test.input, func(t *testing.T) {
+			result := splitInput(test.input)
+			assert.Equal(t, test.expected, result)
+		})
+	}
+}

--- a/kademlia-node/src/cli/command_handler.go
+++ b/kademlia-node/src/cli/command_handler.go
@@ -24,7 +24,7 @@ var (
 // `output` is the io.Writer used for data output.
 // `kademlia` represents the Kademlia node associated with this CLI
 // `commands` is a slice of program commands.
-func (cli *Cli) HandleCommands(output io.Writer, kademliaInstance *kademlia.Kademlia, commands []string) {
+func (cli *Cli) HandleCommands(output io.Writer, kademliaInstance kademlia.Kademlia, commands []string) {
 
 	numArgs := len(commands)
 	command := strings.ToLower(commands[0])
@@ -33,17 +33,31 @@ func (cli *Cli) HandleCommands(output io.Writer, kademliaInstance *kademlia.Kade
 
 	case "put", "p":
 		if numArgs == 2 {
-			Put(*kademliaInstance, commands[1])
+			key, err := Put(kademliaInstance, commands[1])
+			if err != nil {
+				fmt.Fprintln(output, err)
+			} else {
+				fmt.Fprintln(output, "Got hash: "+key)
+
+			}
+
 		} else {
 			fmt.Fprintln(output, noArgsError)
 		}
 
 	case "get", "g":
 		if numArgs == 2 {
-			Get(*kademliaInstance, kademlia.GetKeyRepresentationOfKademliaId(kademlia.NewKademliaID(commands[1])))
+			content, err := Get(kademliaInstance, kademlia.GetKeyRepresentationOfKademliaId(kademlia.NewKademliaID(commands[1])))
+			if err != nil {
+				fmt.Fprintln(output, err)
+			} else {
+				fmt.Fprintln(output, "Got content: "+content)
+
+			}
 		} else {
 			fmt.Fprintln(output, noArgsError)
 		}
+
 	case "kill", "k":
 		if numArgs == 1 {
 			Kill()
@@ -53,8 +67,11 @@ func (cli *Cli) HandleCommands(output io.Writer, kademliaInstance *kademlia.Kade
 
 	case "kademliaid", "kid":
 		if numArgs == 1 {
-			hexRepresentation := *kademliaInstance.KademliaNode.GetRoutingTable().Me.ID
+
+			kademliaNode := *kademliaInstance.GetKademliaNode()
+			hexRepresentation := kademliaNode.GetRoutingTable().Me.ID
 			hexStringRepresentation := hexRepresentation.String()
+
 			fmt.Fprintln(output, hexStringRepresentation)
 		} else {
 			fmt.Fprintln(output, noArgsError)
@@ -80,29 +97,31 @@ func (cli *Cli) HandleCommands(output io.Writer, kademliaInstance *kademlia.Kade
 
 }
 
-func Put(kademlia kademlia.Kademlia, content string) {
+func Put(kademlia kademlia.Kademlia, content string) (string, error) {
 	key, err := kademlia.Store(content)
 
 	if err != nil {
 		log.Printf("Error when storing content: %v\n", err)
+		return "", err
 	} else {
-		fmt.Printf("Got hash: %s\n", key.GetHashString())
+		return key.GetHashString(), nil
 	}
 
 }
 
-func Get(kademlia kademlia.Kademlia, key *kademlia.Key) {
+func Get(kademlia kademlia.Kademlia, key *kademlia.Key) (string, error) {
 	_, value, err := kademlia.LookupData(key)
 
 	if err != nil {
 		log.Printf("Error when looking up data %v\n", err)
-		return
+		return "", err
 	}
 
 	if value != "" {
-		fmt.Printf("Got content: %s\n", value)
-		return
+		return value, nil
 	}
+
+	return "", nil
 }
 
 func Kill() {

--- a/kademlia-node/src/cli/command_handler.go
+++ b/kademlia-node/src/cli/command_handler.go
@@ -53,7 +53,7 @@ func (cli *Cli) HandleCommands(output io.Writer, kademliaInstance *kademlia.Kade
 
 	case "kademliaid", "kid":
 		if numArgs == 1 {
-			hexRepresentation := *kademliaInstance.KademliaNode.RoutingTable.Me.ID
+			hexRepresentation := *kademliaInstance.KademliaNode.GetRoutingTable().Me.ID
 			hexStringRepresentation := hexRepresentation.String()
 			fmt.Fprintln(output, hexStringRepresentation)
 		} else {

--- a/kademlia-node/src/cli/command_handler_test.go
+++ b/kademlia-node/src/cli/command_handler_test.go
@@ -12,16 +12,43 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-// Define a function to create a test Kademlia instance
-func createTestKademlia() *kademlia.Kademlia {
+type KademliaMock struct {
+	DataStore *kademlia.DataStore
+}
+
+func (KademliaMock *KademliaMock) Start() {}
+func (KademliaMock *KademliaMock) Join()  {}
+func (KademliaMock *KademliaMock) Store(content string) (*kademlia.Key, error) {
+	return kademlia.HashToKey(content), nil
+}
+
+func (KademliaMock *KademliaMock) GetKademliaNode() *kademlia.KademliaNode {
+	return nil
+}
+
+func (KademliaMock *KademliaMock) FirstSetContainsAllContactsOfSecondSet(first []kademlia.Contact, second []kademlia.Contact) bool {
+	return false
+}
+
+func (KademliaMock *KademliaMock) LookupContact(targetId *kademlia.KademliaID) ([]kademlia.Contact, error) {
+	return nil, nil
+}
+
+func (KademliaMock *KademliaMock) LookupData(key *kademlia.Key) ([]kademlia.Contact, string, error) {
+	content, err := KademliaMock.DataStore.Get(key)
+	return nil, content, err
+}
+
+// Creates a test Kademlia instance
+func createTestKademlia() *kademlia.KademliaImplementation {
 	kademlia := kademlia.NewKademlia("localhost", 9000, true, "10.0.0.1", 100000)
 	return kademlia
 }
 
-func (cli *Cli) testCommand(command string) string {
+func (cli *Cli) testCommand(commands []string) string {
 	output = bytes.NewBuffer(nil)
 
-	cli.HandleCommands(output, createTestKademlia(), []string{command})
+	cli.HandleCommands(output, cli.kademlia, commands)
 	return trimNewlineFromWriterOutput(output)
 }
 
@@ -30,84 +57,246 @@ func trimNewlineFromWriterOutput(output io.Writer) string {
 	return strings.TrimSuffix(s, "\n")
 }
 
+func TestGet(t *testing.T) {
+	content := "kademlia"
+	key := kademlia.HashToKey(content)
+
+	dataStore := kademlia.NewDataStore()
+	dataStore.Insert(key, content)
+
+	cli := NewCli(&KademliaMock{
+		DataStore: &dataStore,
+	})
+
+	command := []string{
+		"get",
+		key.GetHashString(),
+	}
+
+	output := cli.testCommand(command)
+	assert.Equal(t, "Got content: "+content, output)
+}
+
 func TestGetCommand(t *testing.T) {
 	kademliaInstance := createTestKademlia()
 	cli := NewCli(kademliaInstance)
-	assert.Equal(t, noArgsError, cli.testCommand("get"))
+
+	command := []string{
+		"get",
+	}
+
+	output := cli.testCommand(command)
+	assert.Equal(t, noArgsError, output)
 }
 
 func TestAbbreviatedGetCommand(t *testing.T) {
 	kademliaInstance := createTestKademlia()
 	cli := NewCli(kademliaInstance)
-	assert.Equal(t, noArgsError, cli.testCommand("g"))
+
+	command := []string{
+		"g",
+	}
+
+	output := cli.testCommand(command)
+	assert.Equal(t, noArgsError, output)
+}
+
+func TestPut(t *testing.T) {
+	value := "kademlia"
+	key := kademlia.HashToKey(value)
+
+	cli := NewCli(&KademliaMock{})
+	command := []string{
+		"put",
+		value,
+	}
+
+	output := cli.testCommand(command)
+
+	assert.Equal(t, "Got hash: "+key.GetHashString(), output)
 }
 
 func TestPutCommand(t *testing.T) {
 	kademliaInstance := createTestKademlia()
+
 	cli := NewCli(kademliaInstance)
-	assert.Equal(t, noArgsError, cli.testCommand("put"))
+	command := []string{
+		"put",
+	}
+
+	output := cli.testCommand(command)
+	assert.Equal(t, noArgsError, output)
 }
 
 func TestAbbreviatedPutCommand(t *testing.T) {
 	kademliaInstance := createTestKademlia()
-	cli := NewCli(kademliaInstance)
-	assert.Equal(t, noArgsError, cli.testCommand("p"))
-}
 
-func TestHelpCommand(t *testing.T) {
-	kademliaInstance := createTestKademlia()
 	cli := NewCli(kademliaInstance)
-	content := HelpPrompt()
-	assert.Equal(t, content, cli.testCommand("help"))
-}
+	command := []string{
+		"p",
+	}
 
-func TestAbbreviatedHelpCommand(t *testing.T) {
-	kademliaInstance := createTestKademlia()
-	cli := NewCli(kademliaInstance)
-	content := HelpPrompt()
-	assert.Equal(t, content, cli.testCommand("h"))
-}
-
-func TestKademliaIDCommand(t *testing.T) {
-	kademliaInstance := createTestKademlia()
-	cli := NewCli(kademliaInstance)
-	assert.Equal(t, "ffffffff00000000000000000000000000000000", cli.testCommand("kademliaid"))
-}
-
-func TestAbbreviatedKademliaIDCommand(t *testing.T) {
-	kademliaInstance := createTestKademlia()
-	cli := NewCli(kademliaInstance)
-	assert.Equal(t, "ffffffff00000000000000000000000000000000", cli.testCommand("kid"))
+	output := cli.testCommand(command)
+	assert.Equal(t, noArgsError, output)
 }
 
 func TestKillCommand(t *testing.T) {
 	kademliaInstance := createTestKademlia()
+
 	cli := NewCli(kademliaInstance)
-	assert.Equal(t, 1, cli.exitCli("kill"))
+	command := []string{
+		"kill",
+	}
+
+	output := cli.exitCli(command)
+	assert.Equal(t, 1, output)
 }
 
 func TestAbbreviatedKillCommand(t *testing.T) {
 	kademliaInstance := createTestKademlia()
+
 	cli := NewCli(kademliaInstance)
-	assert.Equal(t, 1, cli.exitCli("k"))
+	command := []string{
+		"k",
+	}
+
+	output := cli.exitCli(command)
+	assert.Equal(t, 1, output)
+}
+
+func TestKillCommandError(t *testing.T) {
+	kademliaInstance := createTestKademlia()
+
+	cli := NewCli(kademliaInstance)
+	command := []string{
+		"kill",
+		"me",
+	}
+
+	output := cli.testCommand(command)
+	assert.Equal(t, noArgsError, output)
+
+}
+
+func TestKademliaIDCommand(t *testing.T) {
+	kademliaInstance := createTestKademlia()
+
+	cli := NewCli(kademliaInstance)
+	command := []string{
+		"kademliaid",
+	}
+
+	output := cli.testCommand(command)
+	assert.Equal(t, "ffffffff00000000000000000000000000000000", output)
+}
+
+func TestAbbreviatedKademliaIDCommand(t *testing.T) {
+	kademliaInstance := createTestKademlia()
+
+	cli := NewCli(kademliaInstance)
+	command := []string{
+		"kid",
+	}
+
+	output := cli.testCommand(command)
+	assert.Equal(t, "ffffffff00000000000000000000000000000000", output)
+}
+
+func TestKademliaIDError(t *testing.T) {
+	kademliaInstance := createTestKademlia()
+
+	cli := NewCli(kademliaInstance)
+	command := []string{
+		"kademliaid",
+		"me",
+	}
+
+	output := cli.testCommand(command)
+	assert.Equal(t, noArgsError, output)
+}
+
+func TestHelpCommand(t *testing.T) {
+	kademliaInstance := createTestKademlia()
+
+	cli := NewCli(kademliaInstance)
+	command := []string{
+		"help",
+	}
+
+	content := HelpPrompt()
+
+	output := cli.testCommand(command)
+	assert.Equal(t, content, output)
+}
+
+func TestAbbreviatedHelpCommand(t *testing.T) {
+	kademliaInstance := createTestKademlia()
+
+	cli := NewCli(kademliaInstance)
+	command := []string{
+		"h",
+	}
+
+	content := HelpPrompt()
+
+	output := cli.testCommand(command)
+	assert.Equal(t, content, output)
+}
+
+func TestHelpCommandError(t *testing.T) {
+	kademliaInstance := createTestKademlia()
+
+	cli := NewCli(kademliaInstance)
+	command := []string{
+		"help",
+		"me",
+	}
+
+	output := cli.testCommand(command)
+	assert.Equal(t, noArgsError, output)
 }
 
 func TestClearCommand(t *testing.T) {
 	kademliaInstance := createTestKademlia()
+
 	cli := NewCli(kademliaInstance)
-	assert.Equal(t, "", cli.testCommand("clear"))
+	command := []string{
+		"clear",
+	}
+
+	output := cli.testCommand(command)
+	assert.Equal(t, "", output)
 }
 
 func TestAbbreviatedClearCommand(t *testing.T) {
 	kademliaInstance := createTestKademlia()
+
 	cli := NewCli(kademliaInstance)
-	assert.Equal(t, "", cli.testCommand("c"))
+	command := []string{
+		"c",
+	}
+
+	output := cli.testCommand(command)
+	assert.Equal(t, "", output)
+}
+
+func TestHelpClearError(t *testing.T) {
+	kademliaInstance := createTestKademlia()
+
+	cli := NewCli(kademliaInstance)
+	command := []string{
+		"clear",
+		"me",
+	}
+
+	output := cli.testCommand(command)
+	assert.Equal(t, noArgsError, output)
 }
 
 // `exitCLI` purpose is for testing cases(`kill`) where the function exits with `os.Exit()`
 // and is slightly modified from the source:
 // https://stackoverflow.com/questions/40615641/testing-os-exit-scenarios-in-go-with-coverage-information-c overalls-io-goverall/40801733#40801733
-func (cli *Cli) exitCli(e string) int {
+func (cli *Cli) exitCli(command []string) int {
 	var got int
 	// Save current function and restore at the end:
 	oldExit := exit
@@ -122,7 +311,7 @@ func (cli *Cli) exitCli(e string) int {
 		exit = oldExit
 	}()
 
-	cli.HandleCommands(output, nil, []string{e})
+	cli.HandleCommands(output, nil, command)
 	return got
 }
 
@@ -148,4 +337,16 @@ func TestClear(t *testing.T) {
 	// Verify that the captured output contains the expected clear command sequence.
 	output := capturingBuffer.String()
 	assert.Equal(t, output, expectedClear)
+}
+
+func TestCommandError(t *testing.T) {
+	kademliaInstance := createTestKademlia()
+
+	cli := NewCli(kademliaInstance)
+	command := []string{
+		"not correct input",
+	}
+
+	output := cli.testCommand(command)
+	assert.Equal(t, commandError, output)
 }

--- a/kademlia-node/src/cli/command_handler_test.go
+++ b/kademlia-node/src/cli/command_handler_test.go
@@ -3,11 +3,12 @@ package cli
 import (
 	"bytes"
 	"io"
+	"log"
+	"os"
 	"strings"
 	"testing"
 
 	"github.com/arianfiftyone/src/kademlia"
-
 	"github.com/stretchr/testify/assert"
 )
 
@@ -91,6 +92,18 @@ func TestAbbreviatedKillCommand(t *testing.T) {
 	assert.Equal(t, 1, cli.exitCli("k"))
 }
 
+func TestClearCommand(t *testing.T) {
+	kademliaInstance := createTestKademlia()
+	cli := NewCli(kademliaInstance)
+	assert.Equal(t, "", cli.testCommand("clear"))
+}
+
+func TestAbbreviatedClearCommand(t *testing.T) {
+	kademliaInstance := createTestKademlia()
+	cli := NewCli(kademliaInstance)
+	assert.Equal(t, "", cli.testCommand("c"))
+}
+
 // `exitCLI` purpose is for testing cases(`kill`) where the function exits with `os.Exit()`
 // and is slightly modified from the source:
 // https://stackoverflow.com/questions/40615641/testing-os-exit-scenarios-in-go-with-coverage-information-c overalls-io-goverall/40801733#40801733
@@ -113,4 +126,26 @@ func (cli *Cli) exitCli(e string) int {
 	return got
 }
 
-// TODO: Add testcase for `clear`-command
+// Not sure if tested correctly
+func TestClear(t *testing.T) {
+	// Backup the original os.Stdout and restore it at the end of the test.
+	originalStdout := os.Stdout
+	defer func() {
+		os.Stdout = originalStdout
+	}()
+
+	// Create a capturing buffer to capture the output.
+	capturingBuffer := &bytes.Buffer{}
+	log.SetOutput(capturingBuffer)
+
+	cli := &Cli{}
+
+	cli.Clear()
+
+	// Define the expected clear command sequence for your system.
+	expectedClear := ""
+
+	// Verify that the captured output contains the expected clear command sequence.
+	output := capturingBuffer.String()
+	assert.Equal(t, output, expectedClear)
+}

--- a/kademlia-node/src/kademlia/kademlia.go
+++ b/kademlia-node/src/kademlia/kademlia.go
@@ -11,7 +11,7 @@ import (
 
 type Kademlia struct {
 	Network          Network
-	KademliaNode     *KademliaNode
+	KademliaNode     KademliaNode
 	isBootstrap      bool
 	bootstrapContact *Contact
 }
@@ -83,7 +83,7 @@ func (kademlia *Kademlia) refresh() {
 	var lowerBound *KademliaID
 	var highBound *KademliaID
 
-	if kademlia.KademliaNode.RoutingTable.Me.ID.Less(kademlia.bootstrapContact.ID) {
+	if kademlia.KademliaNode.GetRoutingTable().Me.ID.Less(kademlia.bootstrapContact.ID) {
 		lowerBound = kademlia.bootstrapContact.ID
 		highBound = NewKademliaID("FFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF")
 	} else {
@@ -100,7 +100,7 @@ func (kademlia *Kademlia) refresh() {
 		return
 	}
 	for _, contact := range contacts {
-		kademlia.KademliaNode.RoutingTable.AddContact(contact)
+		kademlia.KademliaNode.GetRoutingTable().AddContact(contact)
 	}
 
 }
@@ -113,19 +113,19 @@ func (kademlia *Kademlia) Join() {
 
 	}
 
-	err := kademlia.Network.SendPingMessage(&kademlia.KademliaNode.RoutingTable.Me, kademlia.bootstrapContact)
+	err := kademlia.Network.SendPingMessage(&kademlia.KademliaNode.GetRoutingTable().Me, kademlia.bootstrapContact)
 	if err != nil {
 		return
 	}
 
-	kademlia.KademliaNode.RoutingTable.AddContact(*kademlia.bootstrapContact)
+	kademlia.KademliaNode.GetRoutingTable().AddContact(*kademlia.bootstrapContact)
 
-	contacts, err := kademlia.LookupContact(kademlia.KademliaNode.RoutingTable.Me.ID)
+	contacts, err := kademlia.LookupContact(kademlia.KademliaNode.GetRoutingTable().Me.ID)
 	if err != nil {
 		return
 	}
 	for _, contact := range contacts {
-		kademlia.KademliaNode.RoutingTable.AddContact(contact)
+		kademlia.KademliaNode.GetRoutingTable().AddContact(contact)
 	}
 
 	kademlia.refresh()
@@ -145,7 +145,7 @@ func (kademlia *Kademlia) Store(content string) (*Key, error) {
 		return nil, errors.New("found no node to store the value in")
 	}
 	for _, contact := range contacts {
-		kademlia.Network.SendStoreMessage(&kademlia.KademliaNode.RoutingTable.Me, &contact, key, content)
+		kademlia.Network.SendStoreMessage(&kademlia.KademliaNode.GetRoutingTable().Me, &contact, key, content)
 	}
 	return key, nil
 }
@@ -161,10 +161,10 @@ func (kademlia *Kademlia) QueryAlphaContacts(lookupType LookupType, contactsToQu
 			switch lookupType {
 
 			case LOOKUP_CONTACT:
-				foundContacts, err = kademlia.Network.SendFindContactMessage(&kademlia.KademliaNode.RoutingTable.Me, &contactToQuery, &targetId)
+				foundContacts, err = kademlia.Network.SendFindContactMessage(&kademlia.KademliaNode.GetRoutingTable().Me, &contactToQuery, &targetId)
 
 			case LOOKUP_DATA:
-				foundContacts, foundValue, err = kademlia.Network.SendFindDataMessage(&kademlia.KademliaNode.RoutingTable.Me, &contactToQuery, GetKeyRepresentationOfKademliaId(&targetId))
+				foundContacts, foundValue, err = kademlia.Network.SendFindDataMessage(&kademlia.KademliaNode.GetRoutingTable().Me, &contactToQuery, GetKeyRepresentationOfKademliaId(&targetId))
 
 			}
 
@@ -316,7 +316,7 @@ func (kademlia *Kademlia) lookup(lookupType LookupType, targetId *KademliaID) ([
 	queriedContacts := new([]Contact)
 
 	var closestToTargetList *[]Contact
-	alphaClosest := kademlia.KademliaNode.RoutingTable.FindClosestContacts(targetId, NumberOfAlphaContacts)
+	alphaClosest := kademlia.KademliaNode.GetRoutingTable().FindClosestContacts(targetId, NumberOfAlphaContacts)
 	closestToTargetList = &alphaClosest
 
 	lookupCompleteChannel := make(chan bool)

--- a/kademlia-node/src/kademlia/kademlia_node.go
+++ b/kademlia-node/src/kademlia/kademlia_node.go
@@ -4,13 +4,20 @@ const (
 	NumberOfClosestNodesToRetrieved = 3 // Must be atleast 3, otherwize some tests will fail
 )
 
-type KademliaNode struct {
+type KademliaNode interface {
+	setNetwork(network Network)
+	GetRoutingTable() *RoutingTable
+	GetDataStore() *DataStore
+	updateRoutingTable(contact Contact)
+}
+
+type KademliaNodeImplementation struct {
 	Network      Network
 	RoutingTable *RoutingTable
 	DataStore    *DataStore
 }
 
-func NewKademliaNode(ip string, port int, isBootstrap bool) *KademliaNode {
+func NewKademliaNode(ip string, port int, isBootstrap bool) *KademliaNodeImplementation {
 	var routingTable *RoutingTable
 	var kademliaID KademliaID
 
@@ -29,17 +36,25 @@ func NewKademliaNode(ip string, port int, isBootstrap bool) *KademliaNode {
 	// Create new DataStore instance
 	dataStore := NewDataStore()
 
-	return &KademliaNode{
+	return &KademliaNodeImplementation{
 		RoutingTable: routingTable,
 		DataStore:    &dataStore,
 	}
 }
 
-func (kademliaNode *KademliaNode) setNetwork(network Network) {
+func (kademliaNode *KademliaNodeImplementation) setNetwork(network Network) {
 	kademliaNode.Network = network
 }
 
-func (kademliaNode *KademliaNode) updateRoutingTable(contact Contact) {
+func (kademliaNode *KademliaNodeImplementation) GetRoutingTable() *RoutingTable {
+	return kademliaNode.RoutingTable
+}
+
+func (kademliaNode *KademliaNodeImplementation) GetDataStore() *DataStore {
+	return kademliaNode.DataStore
+}
+
+func (kademliaNode *KademliaNodeImplementation) updateRoutingTable(contact Contact) {
 	if kademliaNode.Network == nil {
 		return
 	}

--- a/kademlia-node/src/kademlia/kademlia_test.go
+++ b/kademlia-node/src/kademlia/kademlia_test.go
@@ -297,7 +297,7 @@ func TestLookupContact3(t *testing.T) {
 
 func TestLookupDataFindsData(t *testing.T) {
 
-	bootstrap := CreateMockedKademlia(NewKademliaID("FFFFFFFF00000000000000000000000000000000"), "127.0.0.1", 10020)
+	bootstrap := CreateMockedKademlia(NewKademliaID("FFFFFFFF00000000000000000000000000000000"), "127.0.0.1", 10069)
 
 	kademlia1 := CreateMockedKademlia(NewKademliaID("0000000000000000000000000000000000000001"), "127.0.0.1", 10021)
 	kademlia2 := CreateMockedKademlia(NewKademliaID("0000000000000000000000000000000000000002"), "127.0.0.1", 10022)

--- a/kademlia-node/src/kademlia/kademlia_test.go
+++ b/kademlia-node/src/kademlia/kademlia_test.go
@@ -19,18 +19,18 @@ func TestJoinWithBootstrapOnly(t *testing.T) {
 
 	kademlia.Join()
 
-	contact := kademlia.KademliaNode.RoutingTable.Me
-	assert.Equal(t, contact.ID, kademliaBootsrap.KademliaNode.RoutingTable.FindClosestContacts(contact.ID, 1)[0].ID, "The new node must be in the bootstraps routing table.")
+	contact := kademlia.KademliaNode.GetRoutingTable().Me
+	assert.Equal(t, contact.ID, kademliaBootsrap.KademliaNode.GetRoutingTable().FindClosestContacts(contact.ID, 1)[0].ID, "The new node must be in the bootstraps routing table.")
 
-	bootstrapContact := kademliaBootsrap.KademliaNode.RoutingTable.Me
-	assert.Equal(t, bootstrapContact.ID, kademlia.KademliaNode.RoutingTable.FindClosestContacts(bootstrapContact.ID, 1)[0].ID, "The bootsrapt must be in the new nodes routing table.")
+	bootstrapContact := kademliaBootsrap.KademliaNode.GetRoutingTable().Me
+	assert.Equal(t, bootstrapContact.ID, kademlia.KademliaNode.GetRoutingTable().FindClosestContacts(bootstrapContact.ID, 1)[0].ID, "The bootsrapt must be in the new nodes routing table.")
 
 }
 
 func CreateMockedJoinKademlia(kademliaID *KademliaID, ip string, port int, bootstrapContact *Contact) Kademlia {
 	routingTable := NewRoutingTable(NewContact(kademliaID, ip, port))
 	dataStore := NewDataStore()
-	kademliaNode := &KademliaNode{
+	kademliaNode := &KademliaNodeImplementation{
 		RoutingTable: routingTable,
 		DataStore:    &dataStore,
 	}
@@ -60,22 +60,22 @@ func TestJoinWithMultipleNodes(t *testing.T) {
 	kademlia2 := CreateMockedKademlia(NewKademliaID("0000000000000000000000000000000000000002"), "127.0.0.1", 7002)
 	kademlia3 := CreateMockedKademlia(NewKademliaID("FFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF"), "127.0.0.1", 7003)
 
-	kademliaBootsrap.KademliaNode.RoutingTable.AddContact(kademlia1.KademliaNode.RoutingTable.Me)
-	kademliaBootsrap.KademliaNode.RoutingTable.AddContact(kademlia2.KademliaNode.RoutingTable.Me)
-	kademliaBootsrap.KademliaNode.RoutingTable.AddContact(kademlia3.KademliaNode.RoutingTable.Me)
+	kademliaBootsrap.KademliaNode.GetRoutingTable().AddContact(kademlia1.KademliaNode.GetRoutingTable().Me)
+	kademliaBootsrap.KademliaNode.GetRoutingTable().AddContact(kademlia2.KademliaNode.GetRoutingTable().Me)
+	kademliaBootsrap.KademliaNode.GetRoutingTable().AddContact(kademlia3.KademliaNode.GetRoutingTable().Me)
 
 	go kademliaBootsrap.Start()
 
 	time.Sleep(time.Second)
 
-	kademlia := CreateMockedJoinKademlia(NewKademliaID("0000000000000000000000000000000000000000"), "127.0.0.1", 2001, &kademliaBootsrap.KademliaNode.RoutingTable.Me)
+	kademlia := CreateMockedJoinKademlia(NewKademliaID("0000000000000000000000000000000000000000"), "127.0.0.1", 2001, &kademliaBootsrap.KademliaNode.GetRoutingTable().Me)
 
 	kademlia.Join()
 
-	contacts := kademlia.KademliaNode.RoutingTable.FindClosestContacts(kademlia.KademliaNode.RoutingTable.Me.ID, 20)
+	contacts := kademlia.KademliaNode.GetRoutingTable().FindClosestContacts(kademlia.KademliaNode.GetRoutingTable().Me.ID, 20)
 	fmt.Println(contacts)
-	doesContainAll := kademlia.firstSetContainsAllContactsOfSecondSet(contacts, []Contact{kademlia1.KademliaNode.RoutingTable.Me, kademlia2.KademliaNode.RoutingTable.Me})
-	containsKademlia3 := kademlia.firstSetContainsAllContactsOfSecondSet(contacts, []Contact{kademlia3.KademliaNode.RoutingTable.Me})
+	doesContainAll := kademlia.firstSetContainsAllContactsOfSecondSet(contacts, []Contact{kademlia1.KademliaNode.GetRoutingTable().Me, kademlia2.KademliaNode.GetRoutingTable().Me})
+	containsKademlia3 := kademlia.firstSetContainsAllContactsOfSecondSet(contacts, []Contact{kademlia3.KademliaNode.GetRoutingTable().Me})
 
 	assert.True(t, doesContainAll && containsKademlia3)
 
@@ -115,15 +115,15 @@ func TestLookupContact(t *testing.T) {
 	contact7 := NewContact(NewKademliaID("FFFFFFFF00000000000000000000000000000004"), "198.168.1.7", 3000)
 	contact8 := NewContact(NewKademliaID("FFFFFFFF00000000000000000000000000000005"), "198.168.1.8", 3000)
 	contact9 := NewContact(NewKademliaID("FFFFFFFF00000000000000000000000000000006"), "198.168.1.9", 3000)
-	bootstrap.KademliaNode.RoutingTable.AddContact(contact1)
-	bootstrap.KademliaNode.RoutingTable.AddContact(contact3)
-	bootstrap.KademliaNode.RoutingTable.AddContact(contact4)
-	bootstrap.KademliaNode.RoutingTable.AddContact(contact5)
-	bootstrap.KademliaNode.RoutingTable.AddContact(contact6)
-	bootstrap.KademliaNode.RoutingTable.AddContact(contact7)
-	bootstrap.KademliaNode.RoutingTable.AddContact(contact8)
-	bootstrap.KademliaNode.RoutingTable.AddContact(contact9)
-	bootstrap.KademliaNode.RoutingTable.AddContact(contact2)
+	bootstrap.KademliaNode.GetRoutingTable().AddContact(contact1)
+	bootstrap.KademliaNode.GetRoutingTable().AddContact(contact3)
+	bootstrap.KademliaNode.GetRoutingTable().AddContact(contact4)
+	bootstrap.KademliaNode.GetRoutingTable().AddContact(contact5)
+	bootstrap.KademliaNode.GetRoutingTable().AddContact(contact6)
+	bootstrap.KademliaNode.GetRoutingTable().AddContact(contact7)
+	bootstrap.KademliaNode.GetRoutingTable().AddContact(contact8)
+	bootstrap.KademliaNode.GetRoutingTable().AddContact(contact9)
+	bootstrap.KademliaNode.GetRoutingTable().AddContact(contact2)
 
 	go bootstrap.Start()
 
@@ -131,7 +131,7 @@ func TestLookupContact(t *testing.T) {
 
 	kademlia := NewKademlia("127.0.0.1", 3001, false, "", 0)
 
-	kademlia.KademliaNode.RoutingTable.AddContact(bootstrap.KademliaNode.RoutingTable.Me)
+	kademlia.KademliaNode.GetRoutingTable().AddContact(bootstrap.KademliaNode.GetRoutingTable().Me)
 
 	list, _ := kademlia.LookupContact(contact1.ID)
 
@@ -146,7 +146,7 @@ func TestLookupContact(t *testing.T) {
 func CreateMockedKademlia(kademliaID *KademliaID, ip string, port int) Kademlia {
 	routingTable := NewRoutingTable(NewContact(kademliaID, ip, port))
 	dataStore := NewDataStore()
-	kademliaNode := &KademliaNode{
+	kademliaNode := &KademliaNodeImplementation{
 		RoutingTable: routingTable,
 		DataStore:    &dataStore,
 	}
@@ -178,32 +178,32 @@ func TestLookupContact2(t *testing.T) {
 	kademlia5 := CreateMockedKademlia(NewKademliaID("FFFFFFFF00000000000000000000000000000002"), "127.0.0.1", 7005)
 	kademlia6 := CreateMockedKademlia(NewKademliaID("FFFFFFFF00000000000000000000000000000003"), "127.0.0.1", 7006)
 
-	bootstrap.KademliaNode.RoutingTable.AddContact(kademlia6.KademliaNode.RoutingTable.Me)
-	bootstrap.KademliaNode.RoutingTable.AddContact(kademlia5.KademliaNode.RoutingTable.Me)
+	bootstrap.KademliaNode.GetRoutingTable().AddContact(kademlia6.KademliaNode.GetRoutingTable().Me)
+	bootstrap.KademliaNode.GetRoutingTable().AddContact(kademlia5.KademliaNode.GetRoutingTable().Me)
 
-	kademlia6.KademliaNode.RoutingTable.AddContact(kademlia5.KademliaNode.RoutingTable.Me)
-	kademlia6.KademliaNode.RoutingTable.AddContact(kademlia4.KademliaNode.RoutingTable.Me)
-	kademlia6.KademliaNode.RoutingTable.AddContact(kademlia2.KademliaNode.RoutingTable.Me)
+	kademlia6.KademliaNode.GetRoutingTable().AddContact(kademlia5.KademliaNode.GetRoutingTable().Me)
+	kademlia6.KademliaNode.GetRoutingTable().AddContact(kademlia4.KademliaNode.GetRoutingTable().Me)
+	kademlia6.KademliaNode.GetRoutingTable().AddContact(kademlia2.KademliaNode.GetRoutingTable().Me)
 
-	kademlia5.KademliaNode.RoutingTable.AddContact(kademlia6.KademliaNode.RoutingTable.Me)
-	kademlia5.KademliaNode.RoutingTable.AddContact(kademlia4.KademliaNode.RoutingTable.Me)
-	kademlia5.KademliaNode.RoutingTable.AddContact(kademlia3.KademliaNode.RoutingTable.Me)
+	kademlia5.KademliaNode.GetRoutingTable().AddContact(kademlia6.KademliaNode.GetRoutingTable().Me)
+	kademlia5.KademliaNode.GetRoutingTable().AddContact(kademlia4.KademliaNode.GetRoutingTable().Me)
+	kademlia5.KademliaNode.GetRoutingTable().AddContact(kademlia3.KademliaNode.GetRoutingTable().Me)
 
-	kademlia4.KademliaNode.RoutingTable.AddContact(kademlia1.KademliaNode.RoutingTable.Me)
-	kademlia4.KademliaNode.RoutingTable.AddContact(kademlia5.KademliaNode.RoutingTable.Me)
-	kademlia4.KademliaNode.RoutingTable.AddContact(kademlia6.KademliaNode.RoutingTable.Me)
+	kademlia4.KademliaNode.GetRoutingTable().AddContact(kademlia1.KademliaNode.GetRoutingTable().Me)
+	kademlia4.KademliaNode.GetRoutingTable().AddContact(kademlia5.KademliaNode.GetRoutingTable().Me)
+	kademlia4.KademliaNode.GetRoutingTable().AddContact(kademlia6.KademliaNode.GetRoutingTable().Me)
 
-	kademlia3.KademliaNode.RoutingTable.AddContact(kademlia5.KademliaNode.RoutingTable.Me)
-	kademlia3.KademliaNode.RoutingTable.AddContact(kademlia2.KademliaNode.RoutingTable.Me)
-	kademlia3.KademliaNode.RoutingTable.AddContact(kademlia1.KademliaNode.RoutingTable.Me)
+	kademlia3.KademliaNode.GetRoutingTable().AddContact(kademlia5.KademliaNode.GetRoutingTable().Me)
+	kademlia3.KademliaNode.GetRoutingTable().AddContact(kademlia2.KademliaNode.GetRoutingTable().Me)
+	kademlia3.KademliaNode.GetRoutingTable().AddContact(kademlia1.KademliaNode.GetRoutingTable().Me)
 
-	kademlia2.KademliaNode.RoutingTable.AddContact(kademlia6.KademliaNode.RoutingTable.Me)
-	kademlia2.KademliaNode.RoutingTable.AddContact(kademlia3.KademliaNode.RoutingTable.Me)
-	kademlia2.KademliaNode.RoutingTable.AddContact(kademlia1.KademliaNode.RoutingTable.Me)
+	kademlia2.KademliaNode.GetRoutingTable().AddContact(kademlia6.KademliaNode.GetRoutingTable().Me)
+	kademlia2.KademliaNode.GetRoutingTable().AddContact(kademlia3.KademliaNode.GetRoutingTable().Me)
+	kademlia2.KademliaNode.GetRoutingTable().AddContact(kademlia1.KademliaNode.GetRoutingTable().Me)
 
-	kademlia1.KademliaNode.RoutingTable.AddContact(kademlia4.KademliaNode.RoutingTable.Me)
-	kademlia1.KademliaNode.RoutingTable.AddContact(kademlia3.KademliaNode.RoutingTable.Me)
-	kademlia1.KademliaNode.RoutingTable.AddContact(kademlia2.KademliaNode.RoutingTable.Me)
+	kademlia1.KademliaNode.GetRoutingTable().AddContact(kademlia4.KademliaNode.GetRoutingTable().Me)
+	kademlia1.KademliaNode.GetRoutingTable().AddContact(kademlia3.KademliaNode.GetRoutingTable().Me)
+	kademlia1.KademliaNode.GetRoutingTable().AddContact(kademlia2.KademliaNode.GetRoutingTable().Me)
 
 	go bootstrap.Start()
 	go kademlia1.Start()
@@ -216,14 +216,14 @@ func TestLookupContact2(t *testing.T) {
 
 	kademlia := NewKademlia("127.0.0.1", 4000, false, "", 0)
 
-	kademlia.KademliaNode.RoutingTable.AddContact(bootstrap.KademliaNode.RoutingTable.Me)
+	kademlia.KademliaNode.GetRoutingTable().AddContact(bootstrap.KademliaNode.GetRoutingTable().Me)
 
-	list, _ := kademlia.LookupContact(kademlia1.KademliaNode.RoutingTable.Me.ID)
+	list, _ := kademlia.LookupContact(kademlia1.KademliaNode.GetRoutingTable().Me.ID)
 
 	fmt.Println("closest To Target List")
 	fmt.Println(list)
 
-	doesContainAll := bootstrap.firstSetContainsAllContactsOfSecondSet(list, []Contact{kademlia1.KademliaNode.RoutingTable.Me, kademlia2.KademliaNode.RoutingTable.Me, kademlia3.KademliaNode.RoutingTable.Me})
+	doesContainAll := bootstrap.firstSetContainsAllContactsOfSecondSet(list, []Contact{kademlia1.KademliaNode.GetRoutingTable().Me, kademlia2.KademliaNode.GetRoutingTable().Me, kademlia3.KademliaNode.GetRoutingTable().Me})
 	assert.True(t, doesContainAll)
 
 }
@@ -257,17 +257,17 @@ func TestLookupContact3(t *testing.T) {
 	time.Sleep(1 * time.Second)
 
 	for _, kademlia := range kademlias {
-		bootstrap.KademliaNode.RoutingTable.AddContact(kademlia.KademliaNode.RoutingTable.Me)
-		kademlia.KademliaNode.RoutingTable.AddContact(bootstrap.KademliaNode.RoutingTable.Me)
+		bootstrap.KademliaNode.GetRoutingTable().AddContact(kademlia.KademliaNode.GetRoutingTable().Me)
+		kademlia.KademliaNode.GetRoutingTable().AddContact(bootstrap.KademliaNode.GetRoutingTable().Me)
 
 		fmt.Print("Me: ")
-		fmt.Println(kademlia.KademliaNode.RoutingTable.Me)
-		list, _ := kademlia.LookupContact(kademlia.KademliaNode.RoutingTable.Me.ID)
+		fmt.Println(kademlia.KademliaNode.GetRoutingTable().Me)
+		list, _ := kademlia.LookupContact(kademlia.KademliaNode.GetRoutingTable().Me.ID)
 		// fmt.Print("closestToTargetList: ")
 		// fmt.Println(list)
 
 		for _, contat := range list {
-			kademlia.KademliaNode.RoutingTable.AddContact(contat)
+			kademlia.KademliaNode.GetRoutingTable().AddContact(contat)
 
 		}
 
@@ -278,16 +278,16 @@ func TestLookupContact3(t *testing.T) {
 
 	kademlia := NewKademlia("127.0.0.1", 4000, false, "", 0)
 
-	kademlia.KademliaNode.RoutingTable.AddContact(bootstrap.KademliaNode.RoutingTable.Me)
+	kademlia.KademliaNode.GetRoutingTable().AddContact(bootstrap.KademliaNode.GetRoutingTable().Me)
 
 	for _, kademlia := range kademlias {
-		list, _ := kademlia.LookupContact(kademlia1.KademliaNode.RoutingTable.Me.ID)
-		doesContainAll := bootstrap.firstSetContainsAllContactsOfSecondSet(list, []Contact{kademlia1.KademliaNode.RoutingTable.Me, kademlia2.KademliaNode.RoutingTable.Me, kademlia3.KademliaNode.RoutingTable.Me})
+		list, _ := kademlia.LookupContact(kademlia1.KademliaNode.GetRoutingTable().Me.ID)
+		doesContainAll := bootstrap.firstSetContainsAllContactsOfSecondSet(list, []Contact{kademlia1.KademliaNode.GetRoutingTable().Me, kademlia2.KademliaNode.GetRoutingTable().Me, kademlia3.KademliaNode.GetRoutingTable().Me})
 		assert.True(t, doesContainAll)
 
 		if !doesContainAll {
 			fmt.Print("Me: ")
-			fmt.Println(kademlia.KademliaNode.RoutingTable.Me)
+			fmt.Println(kademlia.KademliaNode.GetRoutingTable().Me)
 			fmt.Print("failed: ")
 			fmt.Println(list)
 		}
@@ -302,13 +302,13 @@ func TestLookupDataFindsData(t *testing.T) {
 	kademlia1 := CreateMockedKademlia(NewKademliaID("0000000000000000000000000000000000000001"), "127.0.0.1", 10021)
 	kademlia2 := CreateMockedKademlia(NewKademliaID("0000000000000000000000000000000000000002"), "127.0.0.1", 10022)
 
-	bootstrap.KademliaNode.RoutingTable.AddContact(kademlia1.KademliaNode.RoutingTable.Me)
-	kademlia1.KademliaNode.RoutingTable.AddContact(kademlia2.KademliaNode.RoutingTable.Me)
+	bootstrap.KademliaNode.GetRoutingTable().AddContact(kademlia1.KademliaNode.GetRoutingTable().Me)
+	kademlia1.KademliaNode.GetRoutingTable().AddContact(kademlia2.KademliaNode.GetRoutingTable().Me)
 
 	value := "value"
 	key := GetKeyRepresentationOfKademliaId(NewKademliaID("0000000000000000000000000000000000000002")) // Sets the key to be the same as kademlia2's id
 
-	kademlia2.KademliaNode.DataStore.Insert(key, value)
+	kademlia2.KademliaNode.GetDataStore().Insert(key, value)
 
 	go bootstrap.Start()
 	go kademlia1.Start()
@@ -317,7 +317,7 @@ func TestLookupDataFindsData(t *testing.T) {
 
 	kademlia := NewKademlia("127.0.0.1", 4020, false, "", 0)
 
-	kademlia.KademliaNode.RoutingTable.AddContact(bootstrap.KademliaNode.RoutingTable.Me)
+	kademlia.KademliaNode.GetRoutingTable().AddContact(bootstrap.KademliaNode.GetRoutingTable().Me)
 
 	_, data, _ := kademlia.LookupData(key)
 
@@ -332,8 +332,8 @@ func TestLookupDataFindsNoData(t *testing.T) {
 	kademlia1 := CreateMockedKademlia(NewKademliaID("0000000000000000000000000000000000000001"), "127.0.0.1", 10031)
 	kademlia2 := CreateMockedKademlia(NewKademliaID("0000000000000000000000000000000000000002"), "127.0.0.1", 10032)
 
-	bootstrap.KademliaNode.RoutingTable.AddContact(kademlia1.KademliaNode.RoutingTable.Me)
-	kademlia1.KademliaNode.RoutingTable.AddContact(kademlia2.KademliaNode.RoutingTable.Me)
+	bootstrap.KademliaNode.GetRoutingTable().AddContact(kademlia1.KademliaNode.GetRoutingTable().Me)
+	kademlia1.KademliaNode.GetRoutingTable().AddContact(kademlia2.KademliaNode.GetRoutingTable().Me)
 
 	value := "value"
 	key := HashToKey(value)
@@ -345,12 +345,12 @@ func TestLookupDataFindsNoData(t *testing.T) {
 
 	kademlia := NewKademlia("127.0.0.1", 4030, false, "", 0)
 
-	kademlia.KademliaNode.RoutingTable.AddContact(bootstrap.KademliaNode.RoutingTable.Me)
+	kademlia.KademliaNode.GetRoutingTable().AddContact(bootstrap.KademliaNode.GetRoutingTable().Me)
 
 	list, _, _ := kademlia.LookupData(key)
 	fmt.Println(list)
 
-	doesContainAll := bootstrap.firstSetContainsAllContactsOfSecondSet(list, []Contact{kademlia1.KademliaNode.RoutingTable.Me, bootstrap.KademliaNode.RoutingTable.Me, kademlia.KademliaNode.RoutingTable.Me})
+	doesContainAll := bootstrap.firstSetContainsAllContactsOfSecondSet(list, []Contact{kademlia1.KademliaNode.GetRoutingTable().Me, bootstrap.KademliaNode.GetRoutingTable().Me, kademlia.KademliaNode.GetRoutingTable().Me})
 	assert.True(t, doesContainAll)
 }
 func TestStore(t *testing.T) {
@@ -363,32 +363,32 @@ func TestStore(t *testing.T) {
 	kademlia5 := CreateMockedKademlia(NewKademliaID("FFFFFFFF00000000000000000000000000000002"), "127.0.0.1", 11005)
 	kademlia6 := CreateMockedKademlia(NewKademliaID("FFFFFFFF00000000000000000000000000000003"), "127.0.0.1", 11006)
 
-	bootstrap.KademliaNode.RoutingTable.AddContact(kademlia6.KademliaNode.RoutingTable.Me)
-	bootstrap.KademliaNode.RoutingTable.AddContact(kademlia5.KademliaNode.RoutingTable.Me)
+	bootstrap.KademliaNode.GetRoutingTable().AddContact(kademlia6.KademliaNode.GetRoutingTable().Me)
+	bootstrap.KademliaNode.GetRoutingTable().AddContact(kademlia5.KademliaNode.GetRoutingTable().Me)
 
-	kademlia6.KademliaNode.RoutingTable.AddContact(kademlia5.KademliaNode.RoutingTable.Me)
-	kademlia6.KademliaNode.RoutingTable.AddContact(kademlia4.KademliaNode.RoutingTable.Me)
-	kademlia6.KademliaNode.RoutingTable.AddContact(kademlia2.KademliaNode.RoutingTable.Me)
+	kademlia6.KademliaNode.GetRoutingTable().AddContact(kademlia5.KademliaNode.GetRoutingTable().Me)
+	kademlia6.KademliaNode.GetRoutingTable().AddContact(kademlia4.KademliaNode.GetRoutingTable().Me)
+	kademlia6.KademliaNode.GetRoutingTable().AddContact(kademlia2.KademliaNode.GetRoutingTable().Me)
 
-	kademlia5.KademliaNode.RoutingTable.AddContact(kademlia6.KademliaNode.RoutingTable.Me)
-	kademlia5.KademliaNode.RoutingTable.AddContact(kademlia4.KademliaNode.RoutingTable.Me)
-	kademlia5.KademliaNode.RoutingTable.AddContact(kademlia3.KademliaNode.RoutingTable.Me)
+	kademlia5.KademliaNode.GetRoutingTable().AddContact(kademlia6.KademliaNode.GetRoutingTable().Me)
+	kademlia5.KademliaNode.GetRoutingTable().AddContact(kademlia4.KademliaNode.GetRoutingTable().Me)
+	kademlia5.KademliaNode.GetRoutingTable().AddContact(kademlia3.KademliaNode.GetRoutingTable().Me)
 
-	kademlia4.KademliaNode.RoutingTable.AddContact(kademlia1.KademliaNode.RoutingTable.Me)
-	kademlia4.KademliaNode.RoutingTable.AddContact(kademlia5.KademliaNode.RoutingTable.Me)
-	kademlia4.KademliaNode.RoutingTable.AddContact(kademlia6.KademliaNode.RoutingTable.Me)
+	kademlia4.KademliaNode.GetRoutingTable().AddContact(kademlia1.KademliaNode.GetRoutingTable().Me)
+	kademlia4.KademliaNode.GetRoutingTable().AddContact(kademlia5.KademliaNode.GetRoutingTable().Me)
+	kademlia4.KademliaNode.GetRoutingTable().AddContact(kademlia6.KademliaNode.GetRoutingTable().Me)
 
-	kademlia3.KademliaNode.RoutingTable.AddContact(kademlia5.KademliaNode.RoutingTable.Me)
-	kademlia3.KademliaNode.RoutingTable.AddContact(kademlia2.KademliaNode.RoutingTable.Me)
-	kademlia3.KademliaNode.RoutingTable.AddContact(kademlia1.KademliaNode.RoutingTable.Me)
+	kademlia3.KademliaNode.GetRoutingTable().AddContact(kademlia5.KademliaNode.GetRoutingTable().Me)
+	kademlia3.KademliaNode.GetRoutingTable().AddContact(kademlia2.KademliaNode.GetRoutingTable().Me)
+	kademlia3.KademliaNode.GetRoutingTable().AddContact(kademlia1.KademliaNode.GetRoutingTable().Me)
 
-	kademlia2.KademliaNode.RoutingTable.AddContact(kademlia6.KademliaNode.RoutingTable.Me)
-	kademlia2.KademliaNode.RoutingTable.AddContact(kademlia3.KademliaNode.RoutingTable.Me)
-	kademlia2.KademliaNode.RoutingTable.AddContact(kademlia1.KademliaNode.RoutingTable.Me)
+	kademlia2.KademliaNode.GetRoutingTable().AddContact(kademlia6.KademliaNode.GetRoutingTable().Me)
+	kademlia2.KademliaNode.GetRoutingTable().AddContact(kademlia3.KademliaNode.GetRoutingTable().Me)
+	kademlia2.KademliaNode.GetRoutingTable().AddContact(kademlia1.KademliaNode.GetRoutingTable().Me)
 
-	kademlia1.KademliaNode.RoutingTable.AddContact(kademlia4.KademliaNode.RoutingTable.Me)
-	kademlia1.KademliaNode.RoutingTable.AddContact(kademlia3.KademliaNode.RoutingTable.Me)
-	kademlia1.KademliaNode.RoutingTable.AddContact(kademlia2.KademliaNode.RoutingTable.Me)
+	kademlia1.KademliaNode.GetRoutingTable().AddContact(kademlia4.KademliaNode.GetRoutingTable().Me)
+	kademlia1.KademliaNode.GetRoutingTable().AddContact(kademlia3.KademliaNode.GetRoutingTable().Me)
+	kademlia1.KademliaNode.GetRoutingTable().AddContact(kademlia2.KademliaNode.GetRoutingTable().Me)
 
 	mockedKademlias := []Kademlia{
 		kademlia1,
@@ -410,7 +410,7 @@ func TestStore(t *testing.T) {
 
 	kademlia := NewKademlia("127.0.0.1", 4000, false, "", 0)
 
-	kademlia.KademliaNode.RoutingTable.AddContact(bootstrap.KademliaNode.RoutingTable.Me)
+	kademlia.KademliaNode.GetRoutingTable().AddContact(bootstrap.KademliaNode.GetRoutingTable().Me)
 
 	content := "testy"
 	key, err := kademlia.Store(content)
@@ -427,9 +427,9 @@ func TestStore(t *testing.T) {
 	for _, contact := range list {
 		contactInMockedKademlias := false
 		for _, kademlia := range mockedKademlias {
-			if kademlia.KademliaNode.RoutingTable.Me.ID == contact.ID {
+			if kademlia.KademliaNode.GetRoutingTable().Me.ID == contact.ID {
 				contactInMockedKademlias = true
-				retrivedContent, err := kademlia.KademliaNode.DataStore.Get(key)
+				retrivedContent, err := kademlia.KademliaNode.GetDataStore().Get(key)
 
 				if err != nil {
 					assert.Fail(t, err.Error())
@@ -441,7 +441,7 @@ func TestStore(t *testing.T) {
 			}
 		}
 		if contactInMockedKademlias {
-			_, err := kademlia.KademliaNode.DataStore.Get(key)
+			_, err := kademlia.KademliaNode.GetDataStore().Get(key)
 
 			if err == nil {
 				assert.Fail(t, "nodes not found by lookup, should not get a store rpc")
@@ -461,7 +461,7 @@ func TestLookupAfterJoin(t *testing.T) {
 	for i := 0; i < 3; i++ {
 		port := 1101 + i
 		kademlia := NewKademlia("localhost", port, false, "localhost", 1100)
-		allContacts = append(allContacts, kademlia.KademliaNode.RoutingTable.Me)
+		allContacts = append(allContacts, kademlia.KademliaNode.GetRoutingTable().Me)
 		go kademlia.Start()
 		time.Sleep(time.Microsecond * 50)
 
@@ -471,7 +471,7 @@ func TestLookupAfterJoin(t *testing.T) {
 
 	target := allContacts[len(allContacts)-1].ID
 
-	allContacts = append(allContacts, bootstrap.KademliaNode.RoutingTable.Me)
+	allContacts = append(allContacts, bootstrap.KademliaNode.GetRoutingTable().Me)
 	var candidates ContactCandidates
 	for i, candidate := range allContacts {
 		candidate.CalcDistance(target)
@@ -518,7 +518,7 @@ func TestBig(t *testing.T) {
 	for i := 0; i < 10; i++ {
 		port := 60001 + i
 		kademlia := NewKademlia("localhost", port, false, "localhost", 60000)
-		allContacts = append(allContacts, kademlia.KademliaNode.RoutingTable.Me)
+		allContacts = append(allContacts, kademlia.KademliaNode.GetRoutingTable().Me)
 		go kademlia.Start()
 		time.Sleep(time.Microsecond * 100)
 
@@ -540,7 +540,7 @@ func TestBig(t *testing.T) {
 			closestToTargetList, _ := kademlia.LookupContact(key.GetKademliaIdRepresentationOfKey())
 
 			fmt.Print("Me: ")
-			fmt.Println(kademlia.KademliaNode.RoutingTable.Me)
+			fmt.Println(kademlia.KademliaNode.GetRoutingTable().Me)
 			fmt.Print("contacts: ")
 			fmt.Println(contacts)
 			fmt.Print("closestToTargetList: ")

--- a/kademlia-node/src/kademlia/kademlia_test.go
+++ b/kademlia-node/src/kademlia/kademlia_test.go
@@ -27,7 +27,7 @@ func TestJoinWithBootstrapOnly(t *testing.T) {
 
 }
 
-func CreateMockedJoinKademlia(kademliaID *KademliaID, ip string, port int, bootstrapContact *Contact) Kademlia {
+func CreateMockedJoinKademlia(kademliaID *KademliaID, ip string, port int, bootstrapContact *Contact) KademliaImplementation {
 	routingTable := NewRoutingTable(NewContact(kademliaID, ip, port))
 	dataStore := NewDataStore()
 	kademliaNode := &KademliaNodeImplementation{
@@ -43,7 +43,7 @@ func CreateMockedJoinKademlia(kademliaID *KademliaID, ip string, port int, boots
 		},
 	}
 	kademliaNode.setNetwork(network)
-	kademlia := Kademlia{
+	kademlia := KademliaImplementation{
 		Network:          network,
 		KademliaNode:     kademliaNode,
 		isBootstrap:      false,
@@ -74,32 +74,11 @@ func TestJoinWithMultipleNodes(t *testing.T) {
 
 	contacts := kademlia.KademliaNode.GetRoutingTable().FindClosestContacts(kademlia.KademliaNode.GetRoutingTable().Me.ID, 20)
 	fmt.Println(contacts)
-	doesContainAll := kademlia.firstSetContainsAllContactsOfSecondSet(contacts, []Contact{kademlia1.KademliaNode.GetRoutingTable().Me, kademlia2.KademliaNode.GetRoutingTable().Me})
-	containsKademlia3 := kademlia.firstSetContainsAllContactsOfSecondSet(contacts, []Contact{kademlia3.KademliaNode.GetRoutingTable().Me})
+	doesContainAll := kademlia.FirstSetContainsAllContactsOfSecondSet(contacts, []Contact{kademlia1.KademliaNode.GetRoutingTable().Me, kademlia2.KademliaNode.GetRoutingTable().Me})
+	containsKademlia3 := kademlia.FirstSetContainsAllContactsOfSecondSet(contacts, []Contact{kademlia3.KademliaNode.GetRoutingTable().Me})
 
 	assert.True(t, doesContainAll && containsKademlia3)
 
-}
-
-type networkMock struct{}
-
-func (network *networkMock) Listen() error {
-	return nil
-}
-func (network *networkMock) Send(ip string, port int, message []byte, timeOut time.Duration) ([]byte, error) {
-	return nil, nil
-}
-func (network *networkMock) SendPingMessage(from *Contact, contact *Contact) error {
-	return nil
-}
-func (network *networkMock) SendFindContactMessage(from *Contact, contact *Contact, id *KademliaID) ([]Contact, error) {
-	return nil, nil
-}
-func (network *networkMock) SendFindDataMessage(from *Contact, contact *Contact, key *Key) ([]Contact, string, error) {
-	return nil, "", nil
-}
-func (network *networkMock) SendStoreMessage(from *Contact, contact *Contact, value string) bool {
-	return false
 }
 
 func TestLookupContact(t *testing.T) {
@@ -138,12 +117,12 @@ func TestLookupContact(t *testing.T) {
 	fmt.Println("closest To Target List")
 	fmt.Println(list)
 
-	doesContainAll := bootstrap.firstSetContainsAllContactsOfSecondSet(list, []Contact{contact1, contact2, contact3})
+	doesContainAll := bootstrap.FirstSetContainsAllContactsOfSecondSet(list, []Contact{contact1, contact2, contact3})
 	assert.True(t, doesContainAll)
 
 }
 
-func CreateMockedKademlia(kademliaID *KademliaID, ip string, port int) Kademlia {
+func CreateMockedKademlia(kademliaID *KademliaID, ip string, port int) KademliaImplementation {
 	routingTable := NewRoutingTable(NewContact(kademliaID, ip, port))
 	dataStore := NewDataStore()
 	kademliaNode := &KademliaNodeImplementation{
@@ -159,7 +138,7 @@ func CreateMockedKademlia(kademliaID *KademliaID, ip string, port int) Kademlia 
 		},
 	}
 	kademliaNode.setNetwork(network)
-	kademlia := Kademlia{
+	kademlia := KademliaImplementation{
 		Network:      network,
 		KademliaNode: kademliaNode,
 		isBootstrap:  true,
@@ -223,7 +202,7 @@ func TestLookupContact2(t *testing.T) {
 	fmt.Println("closest To Target List")
 	fmt.Println(list)
 
-	doesContainAll := bootstrap.firstSetContainsAllContactsOfSecondSet(list, []Contact{kademlia1.KademliaNode.GetRoutingTable().Me, kademlia2.KademliaNode.GetRoutingTable().Me, kademlia3.KademliaNode.GetRoutingTable().Me})
+	doesContainAll := bootstrap.FirstSetContainsAllContactsOfSecondSet(list, []Contact{kademlia1.KademliaNode.GetRoutingTable().Me, kademlia2.KademliaNode.GetRoutingTable().Me, kademlia3.KademliaNode.GetRoutingTable().Me})
 	assert.True(t, doesContainAll)
 
 }
@@ -242,7 +221,7 @@ func TestLookupContact3(t *testing.T) {
 	kademlia8 := CreateMockedKademlia(NewKademliaID("FFFFFFFFFFFFFFFF000000000000000000000000"), "127.0.0.1", 13008)
 	kademlia9 := CreateMockedKademlia(NewKademliaID("0000000FFFFFFFFFFFFFFFF00000000000000000"), "127.0.0.1", 13009)
 
-	kademlias := []Kademlia{kademlia1, kademlia4, kademlia5, kademlia6, kademlia3, kademlia7, kademlia8, kademlia9, kademlia2}
+	kademlias := []KademliaImplementation{kademlia1, kademlia4, kademlia5, kademlia6, kademlia3, kademlia7, kademlia8, kademlia9, kademlia2}
 
 	go bootstrap.Start()
 	go kademlia1.Start()
@@ -282,7 +261,7 @@ func TestLookupContact3(t *testing.T) {
 
 	for _, kademlia := range kademlias {
 		list, _ := kademlia.LookupContact(kademlia1.KademliaNode.GetRoutingTable().Me.ID)
-		doesContainAll := bootstrap.firstSetContainsAllContactsOfSecondSet(list, []Contact{kademlia1.KademliaNode.GetRoutingTable().Me, kademlia2.KademliaNode.GetRoutingTable().Me, kademlia3.KademliaNode.GetRoutingTable().Me})
+		doesContainAll := bootstrap.FirstSetContainsAllContactsOfSecondSet(list, []Contact{kademlia1.KademliaNode.GetRoutingTable().Me, kademlia2.KademliaNode.GetRoutingTable().Me, kademlia3.KademliaNode.GetRoutingTable().Me})
 		assert.True(t, doesContainAll)
 
 		if !doesContainAll {
@@ -350,7 +329,7 @@ func TestLookupDataFindsNoData(t *testing.T) {
 	list, _, _ := kademlia.LookupData(key)
 	fmt.Println(list)
 
-	doesContainAll := bootstrap.firstSetContainsAllContactsOfSecondSet(list, []Contact{kademlia1.KademliaNode.GetRoutingTable().Me, bootstrap.KademliaNode.GetRoutingTable().Me, kademlia.KademliaNode.GetRoutingTable().Me})
+	doesContainAll := bootstrap.FirstSetContainsAllContactsOfSecondSet(list, []Contact{kademlia1.KademliaNode.GetRoutingTable().Me, bootstrap.KademliaNode.GetRoutingTable().Me, kademlia.KademliaNode.GetRoutingTable().Me})
 	assert.True(t, doesContainAll)
 }
 func TestStore(t *testing.T) {
@@ -390,7 +369,7 @@ func TestStore(t *testing.T) {
 	kademlia1.KademliaNode.GetRoutingTable().AddContact(kademlia3.KademliaNode.GetRoutingTable().Me)
 	kademlia1.KademliaNode.GetRoutingTable().AddContact(kademlia2.KademliaNode.GetRoutingTable().Me)
 
-	mockedKademlias := []Kademlia{
+	mockedKademlias := []KademliaImplementation{
 		kademlia1,
 		kademlia2,
 		kademlia3,
@@ -456,7 +435,7 @@ func TestLookupAfterJoin(t *testing.T) {
 	go bootstrap.Start()
 	time.Sleep(time.Second)
 
-	var kademlias []*Kademlia
+	var kademlias []*KademliaImplementation
 	var allContacts []Contact
 	for i := 0; i < 3; i++ {
 		port := 1101 + i
@@ -497,7 +476,7 @@ func TestLookupAfterJoin(t *testing.T) {
 			assert.Fail(t, err.Error())
 		}
 
-		containsAll := bootstrap.firstSetContainsAllContactsOfSecondSet(contacts, expectedClosest)
+		containsAll := bootstrap.FirstSetContainsAllContactsOfSecondSet(contacts, expectedClosest)
 		assert.True(t, containsAll)
 
 		if !containsAll {
@@ -513,12 +492,10 @@ func TestBig(t *testing.T) {
 	go bootstrap.Start()
 	time.Sleep(time.Second)
 
-	var kademlias []*Kademlia
-	var allContacts []Contact
+	var kademlias []*KademliaImplementation
 	for i := 0; i < 10; i++ {
 		port := 60001 + i
 		kademlia := NewKademlia("localhost", port, false, "localhost", 60000)
-		allContacts = append(allContacts, kademlia.KademliaNode.GetRoutingTable().Me)
 		go kademlia.Start()
 		time.Sleep(time.Microsecond * 100)
 

--- a/kademlia-node/src/kademlia/message_handler.go
+++ b/kademlia-node/src/kademlia/message_handler.go
@@ -12,7 +12,7 @@ type MessageHandler interface {
 }
 
 type MessageHandlerImplementation struct {
-	kademliaNode *KademliaNode
+	kademliaNode KademliaNode
 }
 
 func (messageHandler *MessageHandlerImplementation) HandleMessage(rawMessage []byte) ([]byte, error) {
@@ -40,7 +40,7 @@ func (messageHandler *MessageHandlerImplementation) HandleMessage(rawMessage []b
 
 		logger.Log(ping.From.Ip + " sent you a ping")
 
-		pong := NewPongMessage(messageHandler.kademliaNode.RoutingTable.Me)
+		pong := NewPongMessage(messageHandler.kademliaNode.GetRoutingTable().Me)
 		bytes, err := json.Marshal(pong)
 		if err != nil {
 			logger.Log("Error when unmarshaling `pong` message: " + err.Error())
@@ -55,9 +55,9 @@ func (messageHandler *MessageHandlerImplementation) HandleMessage(rawMessage []b
 		json.Unmarshal(rawMessage, &findN)
 
 		logger.Log(findN.From.Ip + " wants to find your k closest nodes.")
-		closestKNodesList := messageHandler.kademliaNode.RoutingTable.FindClosestContacts(findN.ID, NumberOfClosestNodesToRetrieved)
+		closestKNodesList := messageHandler.kademliaNode.GetRoutingTable().FindClosestContacts(findN.ID, NumberOfClosestNodesToRetrieved)
 
-		bytes, err := json.Marshal(NewFoundContactsMessage(messageHandler.kademliaNode.RoutingTable.Me, closestKNodesList))
+		bytes, err := json.Marshal(NewFoundContactsMessage(messageHandler.kademliaNode.GetRoutingTable().Me, closestKNodesList))
 		if err != nil {
 			logger.Log("Error when marshaling `closetsKNodesList`: " + err.Error())
 			return nil, err
@@ -72,10 +72,10 @@ func (messageHandler *MessageHandlerImplementation) HandleMessage(rawMessage []b
 
 		logger.Log(findData.From.Ip + " wants to find a value.")
 
-		data, err := messageHandler.kademliaNode.DataStore.Get(findData.Key)
+		data, err := messageHandler.kademliaNode.GetDataStore().Get(findData.Key)
 		if err != nil {
-			closestKNodesList := messageHandler.kademliaNode.RoutingTable.FindClosestContacts(findData.Key.GetKademliaIdRepresentationOfKey(), NumberOfClosestNodesToRetrieved)
-			bytes, err := json.Marshal(NewFoundDataMessage(messageHandler.kademliaNode.RoutingTable.Me, closestKNodesList, ""))
+			closestKNodesList := messageHandler.kademliaNode.GetRoutingTable().FindClosestContacts(findData.Key.GetKademliaIdRepresentationOfKey(), NumberOfClosestNodesToRetrieved)
+			bytes, err := json.Marshal(NewFoundDataMessage(messageHandler.kademliaNode.GetRoutingTable().Me, closestKNodesList, ""))
 			if err != nil {
 				logger.Log("Error when marshaling `closetsKNodesList`: " + err.Error())
 				return nil, err
@@ -83,7 +83,7 @@ func (messageHandler *MessageHandlerImplementation) HandleMessage(rawMessage []b
 			return bytes, nil
 
 		} else {
-			bytes, err := json.Marshal(NewFoundDataMessage(messageHandler.kademliaNode.RoutingTable.Me, nil, data))
+			bytes, err := json.Marshal(NewFoundDataMessage(messageHandler.kademliaNode.GetRoutingTable().Me, nil, data))
 			if err != nil {
 				logger.Log("Error when marshaling `data`: " + err.Error())
 				return nil, err
@@ -97,11 +97,11 @@ func (messageHandler *MessageHandlerImplementation) HandleMessage(rawMessage []b
 
 		json.Unmarshal(rawMessage, &store)
 
-		messageHandler.kademliaNode.DataStore.Insert(store.Key, store.Value)
+		messageHandler.kademliaNode.GetDataStore().Insert(store.Key, store.Value)
 
 		logger.Log(store.From.Ip + " wants to to store an object at the K(=" + strconv.Itoa(NumberOfClosestNodesToRetrieved) + ") nodes nearest to the hash of the data object in question")
 
-		newStoreResponse := NewStoreResponseMessage(messageHandler.kademliaNode.RoutingTable.Me)
+		newStoreResponse := NewStoreResponseMessage(messageHandler.kademliaNode.GetRoutingTable().Me)
 		bytes, err := json.Marshal(newStoreResponse)
 		if err != nil {
 			logger.Log("Error when marshaling `newStoreResponse`: " + err.Error())
@@ -111,7 +111,7 @@ func (messageHandler *MessageHandlerImplementation) HandleMessage(rawMessage []b
 		return bytes, nil
 
 	default:
-		errorMessage := NewErrorMessage(messageHandler.kademliaNode.RoutingTable.Me)
+		errorMessage := NewErrorMessage(messageHandler.kademliaNode.GetRoutingTable().Me)
 		bytes, err := json.Marshal(errorMessage)
 		if err != nil {
 			logger.Log("Error when marshaling `errorMessage`: " + err.Error())

--- a/kademlia-node/src/kademlia/message_handler_test.go
+++ b/kademlia-node/src/kademlia/message_handler_test.go
@@ -1,0 +1,209 @@
+package kademlia
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+type KademliaNodeMock struct {
+	me        *Contact
+	DataStore *DataStore
+}
+
+func (kademliaNode *KademliaNodeMock) setNetwork(network Network) {
+
+}
+
+func (kademliaNode *KademliaNodeMock) GetRoutingTable() *RoutingTable {
+	return NewRoutingTable(*kademliaNode.me)
+}
+
+func (kademliaNode *KademliaNodeMock) GetDataStore() *DataStore {
+	return kademliaNode.DataStore
+}
+
+func (kademliaNode *KademliaNodeMock) updateRoutingTable(contact Contact) {
+
+}
+
+func TestPongMessage(t *testing.T) {
+	contact := NewContact(NewRandomKademliaID(), "127.0.0.1", 80)
+	messageHandler := &MessageHandlerImplementation{
+		kademliaNode: &KademliaNodeMock{
+			me: &contact,
+		},
+	}
+
+	pong := NewPongMessage(NewContact(NewRandomKademliaID(), "127.0.0.1", 80))
+	bytes, err := json.Marshal(pong)
+	if err != nil {
+		assert.Fail(t, err.Error())
+	}
+	response, err := messageHandler.HandleMessage(bytes)
+	if err != nil {
+		assert.Fail(t, err.Error())
+	}
+	var message Message
+	errUnmarshal := json.Unmarshal(response, &message)
+	if errUnmarshal != nil {
+		assert.Fail(t, errUnmarshal.Error())
+	}
+	assert.Equal(t, ERROR, message.MessageType)
+
+}
+
+func TestPingMessage(t *testing.T) {
+	contact := NewContact(NewRandomKademliaID(), "127.0.0.1", 80)
+	messageHandler := &MessageHandlerImplementation{
+		kademliaNode: &KademliaNodeMock{
+			me: &contact,
+		},
+	}
+
+	ping := NewPingMessage(NewContact(NewRandomKademliaID(), "127.0.0.1", 80))
+	bytes, err := json.Marshal(ping)
+	if err != nil {
+		assert.Fail(t, err.Error())
+	}
+	response, err := messageHandler.HandleMessage(bytes)
+	if err != nil {
+		assert.Fail(t, err.Error())
+	}
+	var message Message
+	errUnmarshal := json.Unmarshal(response, &message)
+	if errUnmarshal != nil {
+		assert.Fail(t, errUnmarshal.Error())
+	}
+	assert.Equal(t, PONG, message.MessageType)
+
+}
+
+func TestFindNodeMessage(t *testing.T) {
+	contact := NewContact(NewRandomKademliaID(), "127.0.0.1", 80)
+	messageHandler := &MessageHandlerImplementation{
+		kademliaNode: &KademliaNodeMock{
+			me: &contact,
+		},
+	}
+
+	target := NewRandomKademliaID()
+	findNode := NewFindNodeMessage(NewContact(NewRandomKademliaID(), "127.0.0.1", 80), target)
+	bytes, err := json.Marshal(findNode)
+	if err != nil {
+		assert.Fail(t, err.Error())
+	}
+	response, err := messageHandler.HandleMessage(bytes)
+	if err != nil {
+		assert.Fail(t, err.Error())
+	}
+	var message Message
+	errUnmarshal := json.Unmarshal(response, &message)
+	if errUnmarshal != nil {
+		assert.Fail(t, errUnmarshal.Error())
+	}
+	assert.Equal(t, FOUND_CONTACTS, message.MessageType)
+
+}
+
+func TestFindDataMessage(t *testing.T) {
+	contact := NewContact(NewRandomKademliaID(), "127.0.0.1", 80)
+	messageHandler := &MessageHandlerImplementation{
+		kademliaNode: &KademliaNodeMock{
+			me:        &contact,
+			DataStore: &DataStore{},
+		},
+	}
+
+	target := NewRandomKademliaID()
+	findData := NewFindDataMessage(NewContact(NewRandomKademliaID(), "127.0.0.1", 80), GetKeyRepresentationOfKademliaId(target))
+	bytes, err := json.Marshal(findData)
+	if err != nil {
+		assert.Fail(t, err.Error())
+	}
+	response, err := messageHandler.HandleMessage(bytes)
+	if err != nil {
+		assert.Fail(t, err.Error())
+	}
+	var message Message
+	errUnmarshal := json.Unmarshal(response, &message)
+	if errUnmarshal != nil {
+		assert.Fail(t, errUnmarshal.Error())
+	}
+	assert.Equal(t, FOUND_DATA, message.MessageType)
+
+}
+
+func TestFindDataMessageDataExists(t *testing.T) {
+	contact := NewContact(NewRandomKademliaID(), "127.0.0.1", 80)
+
+	target := NewRandomKademliaID()
+	dataStore := NewDataStore()
+	value := "test"
+	dataStore.Insert(GetKeyRepresentationOfKademliaId(target), value)
+
+	messageHandler := &MessageHandlerImplementation{
+		kademliaNode: &KademliaNodeMock{
+			me:        &contact,
+			DataStore: &dataStore,
+		},
+	}
+
+	findData := NewFindDataMessage(NewContact(NewRandomKademliaID(), "127.0.0.1", 80), GetKeyRepresentationOfKademliaId(target))
+	bytes, err := json.Marshal(findData)
+	if err != nil {
+		assert.Fail(t, err.Error())
+	}
+	response, err := messageHandler.HandleMessage(bytes)
+	if err != nil {
+		assert.Fail(t, err.Error())
+	}
+	var message Message
+	errUnmarshal := json.Unmarshal(response, &message)
+	if errUnmarshal != nil {
+		assert.Fail(t, errUnmarshal.Error())
+	}
+	assert.Equal(t, FOUND_DATA, message.MessageType)
+
+	var data FoundData
+	errUnmarshalFoundData := json.Unmarshal(response, &data)
+	if errUnmarshalFoundData != nil {
+		assert.Fail(t, errUnmarshal.Error())
+
+	}
+
+	assert.Equal(t, value, data.Value)
+
+}
+
+func TestStoreMessage(t *testing.T) {
+	contact := NewContact(NewRandomKademliaID(), "127.0.0.1", 80)
+	dataStore := NewDataStore()
+	value := "test"
+
+	messageHandler := &MessageHandlerImplementation{
+		kademliaNode: &KademliaNodeMock{
+			me:        &contact,
+			DataStore: &dataStore,
+		},
+	}
+
+	target := NewRandomKademliaID()
+	store := NewStoreMessage(NewContact(NewRandomKademliaID(), "127.0.0.1", 80), GetKeyRepresentationOfKademliaId(target), value)
+	bytes, err := json.Marshal(store)
+	if err != nil {
+		assert.Fail(t, err.Error())
+	}
+	response, err := messageHandler.HandleMessage(bytes)
+	if err != nil {
+		assert.Fail(t, err.Error())
+	}
+	var message Message
+	errUnmarshal := json.Unmarshal(response, &message)
+	if errUnmarshal != nil {
+		assert.Fail(t, errUnmarshal.Error())
+	}
+	assert.Equal(t, STORE_RESPONSE, message.MessageType)
+
+}

--- a/kademlia-node/src/kademlia/network_test.go
+++ b/kademlia-node/src/kademlia/network_test.go
@@ -176,10 +176,10 @@ func TestSendNodeDataMessage(t *testing.T) {
 	value := "data"
 	key := HashToKey(value)
 
-	bootstrap.KademliaNode.DataStore.Insert(key, value)
+	bootstrap.KademliaNode.GetDataStore().Insert(key, value)
 	go bootstrap.Start()
 	time.Sleep(time.Second)
-	_, str, _ := bootstrap.Network.SendFindDataMessage(&bootstrap.KademliaNode.RoutingTable.Me, &bootstrap.KademliaNode.RoutingTable.Me, key)
+	_, str, _ := bootstrap.Network.SendFindDataMessage(&bootstrap.KademliaNode.GetRoutingTable().Me, &bootstrap.KademliaNode.GetRoutingTable().Me, key)
 
 	assert.Equal(t, str, value)
 }
@@ -191,16 +191,16 @@ func TestSendNodeDataMessageNoData(t *testing.T) {
 	kademlia1 := CreateMockedKademlia(NewKademliaID("0000000000000000000000000000000000000001"), "127.0.0.1", 7011)
 	kademlia2 := CreateMockedKademlia(NewKademliaID("0000000000000000000000000000000000000002"), "127.0.0.1", 7012)
 
-	bootstrap.KademliaNode.RoutingTable.AddContact(kademlia1.KademliaNode.RoutingTable.Me)
-	bootstrap.KademliaNode.RoutingTable.AddContact(kademlia2.KademliaNode.RoutingTable.Me)
+	bootstrap.KademliaNode.GetRoutingTable().AddContact(kademlia1.KademliaNode.GetRoutingTable().Me)
+	bootstrap.KademliaNode.GetRoutingTable().AddContact(kademlia2.KademliaNode.GetRoutingTable().Me)
 
 	go bootstrap.Start()
 	time.Sleep(time.Second)
 	value := "data"
 	key := HashToKey(value)
-	contacts, _, _ := bootstrap.Network.SendFindDataMessage(&bootstrap.KademliaNode.RoutingTable.Me, &bootstrap.KademliaNode.RoutingTable.Me, key)
+	contacts, _, _ := bootstrap.Network.SendFindDataMessage(&bootstrap.KademliaNode.GetRoutingTable().Me, &bootstrap.KademliaNode.GetRoutingTable().Me, key)
 
-	kClosest := bootstrap.KademliaNode.RoutingTable.FindClosestContacts(bootstrap.KademliaNode.RoutingTable.Me.ID, NumberOfClosestNodesToRetrieved)
+	kClosest := bootstrap.KademliaNode.GetRoutingTable().FindClosestContacts(bootstrap.KademliaNode.GetRoutingTable().Me.ID, NumberOfClosestNodesToRetrieved)
 	doesContainAll := bootstrap.firstSetContainsAllContactsOfSecondSet(kClosest, contacts)
 	assert.True(t, doesContainAll)
 }

--- a/kademlia-node/src/kademlia/network_test.go
+++ b/kademlia-node/src/kademlia/network_test.go
@@ -201,7 +201,7 @@ func TestSendNodeDataMessageNoData(t *testing.T) {
 	contacts, _, _ := bootstrap.Network.SendFindDataMessage(&bootstrap.KademliaNode.GetRoutingTable().Me, &bootstrap.KademliaNode.GetRoutingTable().Me, key)
 
 	kClosest := bootstrap.KademliaNode.GetRoutingTable().FindClosestContacts(bootstrap.KademliaNode.GetRoutingTable().Me.ID, NumberOfClosestNodesToRetrieved)
-	doesContainAll := bootstrap.firstSetContainsAllContactsOfSecondSet(kClosest, contacts)
+	doesContainAll := bootstrap.FirstSetContainsAllContactsOfSecondSet(kClosest, contacts)
 	assert.True(t, doesContainAll)
 }
 


### PR DESCRIPTION
- more tests for `cli.go`
- more tests for `command_handler.go`
- added `KademliaMock` in `command_handler.go` when testing `Put` and `Get`
- added script `run_coverage.sh` in `scripts`-folder to get coverage of repository:
- simply cd into folder and type `./run_coverage.sh` to get `coverage.out` and `coverage.html`