### PR TITLE
Hotfix newkey

### DIFF
--- a/kademlia-node/src/kademlia/datastore_test.go
+++ b/kademlia-node/src/kademlia/datastore_test.go
@@ -60,7 +60,7 @@ func TestInsertAndGetTime(t *testing.T) {
 
 	// Insert a key-value pair
 	value := "testValue"
-	key := HashToKey(value)
+	key := NewKey(value)
 	dataStore.Insert(key, value)
 
 	// Retrieve the time associated with the key

--- a/kademlia-node/src/kademlia/kademlia_test.go
+++ b/kademlia-node/src/kademlia/kademlia_test.go
@@ -306,10 +306,10 @@ func TestLookupDataFindsData(t *testing.T) {
 
 func TestLookupDataFindsNoData(t *testing.T) {
 
-	bootstrap := CreateMockedKademlia(GenerateNewKademliaID("FFFFFFFF00000000000000000000000000000000"), "127.0.0.1", 10030)
+	bootstrap := CreateMockedKademlia(GenerateNewKademliaID("FFFFFFFF00000000000000000000000000000000"), "127.0.0.1", 10031)
 
-	kademlia1 := CreateMockedKademlia(GenerateNewKademliaID("0000000000000000000000000000000000000001"), "127.0.0.1", 10031)
-	kademlia2 := CreateMockedKademlia(GenerateNewKademliaID("0000000000000000000000000000000000000002"), "127.0.0.1", 10032)
+	kademlia1 := CreateMockedKademlia(GenerateNewKademliaID("0000000000000000000000000000000000000001"), "127.0.0.1", 10032)
+	kademlia2 := CreateMockedKademlia(GenerateNewKademliaID("0000000000000000000000000000000000000002"), "127.0.0.1", 10033)
 
 	bootstrap.KademliaNode.GetRoutingTable().AddContact(kademlia1.KademliaNode.GetRoutingTable().Me)
 	kademlia1.KademliaNode.GetRoutingTable().AddContact(kademlia2.KademliaNode.GetRoutingTable().Me)


### PR DESCRIPTION
- `HashToKey` did not rename to `NewKey` correctly in all files somehow. Works now.
- `kademlia_test.go` had port conflicts which are now resolved