### PR TITLE
Reset expiration time

### DIFF
--- a/kademlia-node/src/kademlia/datastore.go
+++ b/kademlia-node/src/kademlia/datastore.go
@@ -33,6 +33,10 @@ func (dataStore DataStore) Get(key *Key) (string, error) {
 	if !ok {
 		return "", errors.New("key not found")
 	}
+	err := dataStore.RefreshExpirationTime(key)
+	if err != nil {
+		return "", errors.New("Refresh failed")
+	}
 	return value, nil
 }
 

--- a/kademlia-node/src/kademlia/message.go
+++ b/kademlia-node/src/kademlia/message.go
@@ -20,7 +20,7 @@ const (
 
 func (messageType MessageType) IsValid() error {
 	switch messageType {
-	case ERROR, PING, PONG, FIND_NODE, FIND_DATA, STORE, STORE_RESPONSE, FOUND_CONTACTS, FOUND_DATA, REFRESH_EXPIRATION_TIME: // Add new messageTypes to the case, so it is seen as a valid type
+	case ERROR, PING, PONG, FIND_NODE, FIND_DATA, STORE, STORE_RESPONSE, FOUND_CONTACTS, FOUND_DATA, REFRESH_EXPIRATION_TIME, EXPIRATION_TIME_HAS_BEEN_REFRESHED: // Add new messageTypes to the case, so it is seen as a valid type
 		return nil
 	}
 	return errors.New("Invalid message type")


### PR DESCRIPTION
Every time a object is retrieved from the `DataStore` the objects expiration time is reset and the message `EXPIRATION_TIME_HAS_BEEN_REFRESHED` has been added to valid messages