### PR TITLE
Implements mutex locks in dataStore 

### DIFF
--- a/kademlia-node/src/kademlia/datastore.go
+++ b/kademlia-node/src/kademlia/datastore.go
@@ -1,8 +1,8 @@
 package kademlia
 
 import (
-	"encoding/hex"
 	"errors"
+	"sync"
 	"time"
 
 	"github.com/arianfiftyone/src/logger"
@@ -10,9 +10,10 @@ import (
 
 // DataStore represents a key-value data store.
 type DataStore struct {
-	data map[[KeySize]byte]string    // Map to store key-value pairs.
-	time map[[KeySize]byte]time.Time // Map to store key-time for expiration pairs. Unix time.
-	ttl  time.Duration               //seconds
+	data       map[[KeySize]byte]string      // Map to store key-value pairs.
+	time       map[[KeySize]byte]time.Time   // Map to store key-time for expiration pairs. Unix time.
+	mutexLocks map[[KeySize]byte]*sync.Mutex // Map to store a mutex lock for each key.
+	ttl        time.Duration                 //seconds
 }
 
 // NewDataStore initializes a new DataStore instance.
@@ -20,49 +21,86 @@ func NewDataStore() DataStore {
 	dataStore := DataStore{}
 	dataStore.data = make(map[[KeySize]byte]string)
 	dataStore.time = make(map[[KeySize]byte]time.Time)
+	dataStore.mutexLocks = make(map[[20]byte]*sync.Mutex)
 	dataStore.ttl = time.Second * 10
 	return dataStore
 }
 
 // Insert inserts a key-value pair into the DataStore.
 func (dataStore DataStore) Insert(key *Key, value string) {
+	dataStore.mutexLocks[key.Hash] = &sync.Mutex{}
+	mutex := dataStore.mutexLocks[key.Hash]
+	mutex.Lock()
+
 	dataStore.time[key.Hash] = dataStore.calculateExpirationTime()
 	dataStore.data[key.Hash] = value
 
-	go dataStore.deleteAfterExpirationTime(dataStore.ttl, key.Hash)
+	mutex.Unlock()
+	go dataStore.deleteAfterExpirationTime(dataStore.ttl, key)
 }
 
-func (dataStore DataStore) deleteAfterExpirationTime(timer time.Duration, hash [KeySize]byte) {
+func (dataStore DataStore) deleteAfterExpirationTime(timer time.Duration, key *Key) {
 
 	select {
 	case currTime := <-time.After(timer):
-		differenceInTime := dataStore.time[hash].Sub(currTime)
-		if differenceInTime <= 0 {
-			dataStore.DeleteExpiredData(hash)
-		} else {
-			dataStore.deleteAfterExpirationTime(differenceInTime, hash)
+		mutex, ok := dataStore.mutexLocks[key.Hash]
+		if !ok {
+			return
 		}
+		mutex.Lock()
+
+		_, ok = dataStore.time[key.Hash]
+		if !ok {
+			mutex.Unlock()
+			return
+		}
+
+		differenceInTime := dataStore.time[key.Hash].Sub(currTime)
+		mutex.Unlock()
+		if differenceInTime <= 0 {
+			dataStore.Delete(key)
+		} else {
+			dataStore.deleteAfterExpirationTime(differenceInTime, key)
+		}
+
 	}
 }
 
 // Get retrieves the value associated with a key from the DataStore.
 func (dataStore DataStore) Get(key *Key) (string, error) {
-	value, ok := dataStore.data[key.Hash]
+	mutex, ok := dataStore.mutexLocks[key.Hash]
 	if !ok {
 		return "", errors.New("key not found")
 	}
+	mutex.Lock()
+
+	value, ok := dataStore.data[key.Hash]
+	if !ok {
+		mutex.Unlock()
+		return "", errors.New("key not found")
+	}
+	mutex.Unlock()
 	err := dataStore.RefreshExpirationTime(key)
 	if err != nil {
 		return "", errors.New("Refresh failed")
 	}
+
 	return value, nil
 }
 
 func (dataStore DataStore) GetTime(key *Key) (time.Time, error) {
+	mutex, ok := dataStore.mutexLocks[key.Hash]
+	if !ok {
+		return time.Now(), errors.New("key not found")
+	}
+	mutex.Lock()
+
 	time, ok := dataStore.time[key.Hash]
 	if !ok {
+		mutex.Unlock()
 		return time, errors.New("key not found")
 	}
+	mutex.Unlock()
 	return time, nil
 }
 
@@ -71,18 +109,45 @@ func (dataStore DataStore) calculateExpirationTime() time.Time {
 }
 
 func (dataStore DataStore) RefreshExpirationTime(key *Key) error {
-	_, ok := dataStore.data[key.Hash]
+	mutex, ok := dataStore.mutexLocks[key.Hash]
 	if !ok {
+		return errors.New("key not found")
+	}
+	mutex.Lock()
+
+	_, ok = dataStore.data[key.Hash]
+	if !ok {
+		mutex.Unlock()
 		return errors.New("key not found")
 	}
 	ttl := dataStore.calculateExpirationTime()
 	dataStore.time[key.Hash] = ttl
+	mutex.Unlock()
 	return nil
 }
 
-func (dataStore DataStore) DeleteExpiredData(dataToDelete [KeySize]byte) {
-	value := dataStore.data[dataToDelete]
-	delete(dataStore.time, dataToDelete)
-	delete(dataStore.data, dataToDelete)
-	logger.Log("The data object " + hex.EncodeToString(dataToDelete[:]) + " with the value " + value + " has been deleted due to the expired TTL.")
+func (dataStore DataStore) Delete(key *Key) error {
+	mutex, ok := dataStore.mutexLocks[key.Hash]
+	if !ok {
+		return errors.New("key not found")
+	}
+	mutex.Lock()
+
+	value, ok := dataStore.data[key.Hash]
+	if !ok {
+		mutex.Unlock()
+		return errors.New("key not found")
+	}
+	_, ok = dataStore.time[key.Hash]
+	if !ok {
+		mutex.Unlock()
+		return errors.New("key not found")
+	}
+
+	delete(dataStore.time, key.Hash)
+	delete(dataStore.data, key.Hash)
+	delete(dataStore.mutexLocks, key.Hash)
+	mutex.Unlock()
+	logger.Log("The data object " + key.GetHashString() + " with the value " + value + " has been deleted due to the expired TTL.")
+	return nil
 }

--- a/kademlia-node/src/kademlia/datastore_test.go
+++ b/kademlia-node/src/kademlia/datastore_test.go
@@ -127,7 +127,7 @@ func TestDeleteExpiredData(t *testing.T) {
 	dataStore.data[key.Hash] = value
 	dataStore.time[key.Hash] = dataStore.calculateExpirationTime()
 
-	dataStore.DeleteExpiredData(key.Hash)
+	dataStore.Delete(key)
 
 	//expectedMap := map[[KeySize]byte]string{}
 


### PR DESCRIPTION
A mutex lock is added for each key entered in the dataStore. This is to synchronize the retrieval and deletion of objects stored and avoid the case where one node retrieves the value at the same time as it is deleted and thus corrupting the object.   

Additionally `func (dataStore DataStore) deleteAfterExpirationTime(timer time.Duration, hash [KeySize]byte)` is changed to `func (dataStore DataStore) deleteAfterExpirationTime(timer time.Duration, key *Key) ` this is to use the `Key` object in all places, this is changed in some other places as well. Also the function `DeleteExpiredData` is renamed to `Delete`, this is because the function has nothing to do with expired time and only deletes regardless. 