### PR TITLE
Implemented Forget in CLI and test.

### DIFF
--- a/kademlia-node/src/api/kademlia_api_test.go
+++ b/kademlia-node/src/api/kademlia_api_test.go
@@ -48,6 +48,10 @@ func (KademliaMock *KademliaMock) LookupData(key *kademlia.Key) ([]kademlia.Cont
 	return nil, content, err
 }
 
+func (KademliaMock *KademliaMock) Forget(key *kademlia.Key) error {
+	return nil
+}
+
 func TestGetObjectValidHash(t *testing.T) {
 
 	kademliaMock := new(KademliaMock)

--- a/kademlia-node/src/cli/command_handler.go
+++ b/kademlia-node/src/cli/command_handler.go
@@ -59,7 +59,11 @@ func (cli *Cli) HandleCommands(output io.Writer, kademliaInstance kademlia.Kadem
 				customErr := fmt.Errorf("error when looking up data %s", err.Error())
 				fmt.Fprintln(output, customErr)
 			} else {
-				fmt.Fprintln(output, "Got content: "+content)
+				if content != "" {
+					fmt.Fprintln(output, "Got content: "+content)
+				} else {
+					fmt.Fprintln(output, "Does not exist.")
+				}
 
 			}
 		} else {
@@ -95,6 +99,28 @@ func (cli *Cli) HandleCommands(output io.Writer, kademliaInstance kademlia.Kadem
 	case "clear", "c":
 		if numArgs == 1 {
 			cli.Clear()
+		} else {
+			fmt.Fprintln(output, noArgsError)
+		}
+
+	case "forget":
+		if numArgs == 2 {
+			kademliaId, err := kademlia.NewKademliaID(commands[1])
+			if err != nil {
+				customErr := fmt.Errorf("error when creating new kademliaID %s", err.Error())
+				fmt.Fprintln(output, customErr)
+				return
+			}
+
+			err = Forget(kademliaInstance, kademlia.GetKeyRepresentationOfKademliaId(kademliaId))
+
+			if err != nil {
+				customErr := fmt.Errorf("error when forgetting data %s", err.Error())
+				fmt.Fprintln(output, customErr)
+			} else {
+				fmt.Fprintln(output, "The data object has stopped being refreshed.")
+			}
+
 		} else {
 			fmt.Fprintln(output, noArgsError)
 		}
@@ -138,4 +164,14 @@ func Kill() {
 func Help(output io.Writer) {
 	text := HelpPrompt()
 	fmt.Fprintln(output, text)
+}
+
+func Forget(kademlia kademlia.Kademlia, key *kademlia.Key) error {
+	err := kademlia.Forget(key)
+
+	if err != nil {
+		return err
+	}
+
+	return nil
 }

--- a/kademlia-node/src/cli/command_handler_test.go
+++ b/kademlia-node/src/cli/command_handler_test.go
@@ -39,6 +39,10 @@ func (KademliaMock *KademliaMock) LookupData(key *kademlia.Key) ([]kademlia.Cont
 	return nil, content, err
 }
 
+func (KademliaMock *KademliaMock) Forget(key *kademlia.Key) error {
+	return nil
+}
+
 // Creates a test Kademlia instance
 func createTestKademlia() *kademlia.KademliaImplementation {
 	kademlia := kademlia.NewKademlia("localhost", 9000, true, "10.0.0.1", 100000)
@@ -349,4 +353,31 @@ func TestCommandError(t *testing.T) {
 
 	output := cli.testCommand(command)
 	assert.Equal(t, commandError, output)
+}
+
+func TestForget(t *testing.T) {
+	value := "kademlia"
+	key := kademlia.NewKey(value)
+
+	cli := NewCli(&KademliaMock{})
+	command := []string{
+		"forget",
+		key.GetHashString(),
+	}
+
+	output := cli.testCommand(command)
+
+	assert.Equal(t, "The data object has stopped being refreshed.", output)
+}
+
+func TestForgetCommand(t *testing.T) {
+	kademliaInstance := createTestKademlia()
+
+	cli := NewCli(kademliaInstance)
+	command := []string{
+		"forget",
+	}
+
+	output := cli.testCommand(command)
+	assert.Equal(t, noArgsError, output)
 }

--- a/kademlia-node/src/kademlia/kademlia.go
+++ b/kademlia-node/src/kademlia/kademlia.go
@@ -17,6 +17,7 @@ type Kademlia interface {
 	FirstSetContainsAllContactsOfSecondSet(first []Contact, second []Contact) bool
 	LookupContact(targetId *KademliaID) ([]Contact, error)
 	LookupData(key *Key) ([]Contact, string, error)
+	Forget(key *Key) error
 }
 
 type KademliaImplementation struct {
@@ -141,6 +142,16 @@ func (kademlia *KademliaImplementation) Join() {
 	}
 
 	kademlia.refresh()
+}
+
+func (kademlia *KademliaImplementation) Forget(key *Key) error {
+	_, ok := kademlia.keyToStopRefreshMap[key.Hash]
+	if !ok {
+		return errors.New("key not found")
+	}
+
+	kademlia.keyToStopRefreshMap[key.Hash] <- true
+	return nil
 }
 
 func (kademlia *KademliaImplementation) Store(content string) (*Key, error) {

--- a/kademlia-node/src/kademlia/kademlia_test.go
+++ b/kademlia-node/src/kademlia/kademlia_test.go
@@ -604,3 +604,32 @@ func TestStopRefresh(t *testing.T) {
 
 	assert.Equal(t, initTime, endTime)
 }
+
+func TestForget(t *testing.T) {
+	bootstrap := CreateMockedKademlia(GenerateNewKademliaID("FFFFFFFF00000000000000000000000000000000"), "127.0.0.1", 31011)
+
+	go bootstrap.Start()
+	time.Sleep(time.Second)
+
+	kademlia := NewKademlia("127.0.0.1", 4001, false, "", 0)
+
+	kademlia.KademliaNode.GetRoutingTable().AddContact(bootstrap.KademliaNode.GetRoutingTable().Me)
+
+	content := "testy"
+	key, err := kademlia.Store(content)
+
+	if err != nil {
+		assert.Fail(t, err.Error())
+	}
+
+	err = kademlia.Forget(key)
+	if err != nil {
+		assert.Fail(t, err.Error())
+	}
+
+	time.Sleep((bootstrap.KademliaNode.GetDataStore().ttl / 2) + time.Millisecond*100)
+
+	expectedMap := map[[KeySize]byte]string{}
+
+	assert.Equal(t, expectedMap, kademlia.KademliaNode.GetDataStore().data)
+}


### PR DESCRIPTION
Implemented **Forget** in **CLI** by calling on a newly added function **Forget** in **kademlia.go**.  A test for it has been added.